### PR TITLE
Dockerfile for ARMv8 support for Node-RED

### DIFF
--- a/aarch64/Dockerfile
+++ b/aarch64/Dockerfile
@@ -1,0 +1,30 @@
+FROM aarch64/node:4.6-slim
+
+# Experimental ARMv8 support for Node-RED
+
+# Home directory for Node-RED application source code.
+RUN mkdir -p /usr/src/node-red
+
+# User data directory, contains flows, config and nodes.
+RUN mkdir /data
+
+WORKDIR /usr/src/node-red
+
+# Add node-red user so we aren't running as root.
+RUN useradd --home-dir /usr/src/node-red --no-create-home node-red \
+    && chown -R node-red:node-red /data \
+    && chown -R node-red:node-red /usr/src/node-red
+
+USER node-red
+
+# package.json contains Node-RED NPM module and node dependencies
+COPY package.json /usr/src/node-red/
+RUN npm install
+
+# User configuration directory volume
+EXPOSE 1880
+
+# Environment variable holding file path for flows configuration
+ENV FLOWS=flows.json
+
+CMD ["npm", "start", "--", "--userDir", "/data"]


### PR DESCRIPTION
This Dockerfile adds ARMv8 support for Node-RED, using the aarch64/node support. Please note from that distribution:

THESE IMAGES ARE VERY, VERY EXPERIMENTAL; THEY ARE PROVIDED ON A BEST-EFFORT BASIS WHILE docker/docker#15866 IS STILL IN-PROGRESS -- PLEASE DO NOT USE THEM FOR ANYTHING SERIOUS OR IMPORTANT (aside from the important task of CI for testing Docker itself, which is one of their primary purposes for existence).
