### PR TITLE
Make user flows persistent

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -20,6 +20,9 @@ USER node-red
 COPY package.json /usr/src/node-red/
 RUN npm install
 
+# Make user flows persistent
+VOLUME ["/data"]
+
 # User configuration directory volume
 EXPOSE 1880
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

Without having the VOLUME statement user flows do not persist. Further, when following the guide here https://nodered.org/docs/platforms/docker and attempting to map the /data directory to a host directory the settings.js, lib and package.json are lost with the suggested command: `docker run -it -p 1880:1880 -v ~/node-red-data:/data --name mynodered nodered/node-red-docker`

Alternatively allowing docker to select the volume location with this syntax does not clear the /data directory:
```
docker run -d \
--name nodered \
--restart always \
-p 1880:1880 \
-v node-red_data:/data \
nodered/node-red-docker
```

Note using docker version:
```
$ docker --version
Docker version 18.06.1-ce, build e68fc7a
```

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [n/a] I have run `grunt` to verify the unit tests pass
- [n/a] I have added suitable unit tests to cover the new/changed functionality

Error message in full:
```
$ docker run -it -p 1880:1880 -v ~/node-red-data:/data --name mynodered nodered/node-red-docker

> node-red-docker@1.0.0 start /usr/src/node-red
> node $NODE_OPTIONS node_modules/node-red/red.js -v $FLOWS "--userDir" "/data"

fs.js:642
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: EACCES: permission denied, open '/data/settings.js'
    at Error (native)
    at Object.fs.openSync (fs.js:642:18)
    at copyFileFallback (/usr/src/node-red/node_modules/fs-extra/lib/copy-sync/copy-sync.js:93:18)
    at copyFile (/usr/src/node-red/node_modules/fs-extra/lib/copy-sync/copy-sync.js:85:10)
    at onFile (/usr/src/node-red/node_modules/fs-extra/lib/copy-sync/copy-sync.js:58:12)
    at getStats (/usr/src/node-red/node_modules/fs-extra/lib/copy-sync/copy-sync.js:51:39)
    at startCopy (/usr/src/node-red/node_modules/fs-extra/lib/copy-sync/copy-sync.js:41:10)
    at Object.copySync (/usr/src/node-red/node_modules/fs-extra/lib/copy-sync/copy-sync.js:36:10)
    at Object.<anonymous> (/usr/src/node-red/node_modules/node-red/red.js:104:20)
    at Module._compile (module.js:577:32)

npm ERR! Linux 4.4.0-131-generic
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "start" "--" "--userDir" "/data"
npm ERR! node v6.14.4
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! node-red-docker@1.0.0 start: `node $NODE_OPTIONS node_modules/node-red/red.js -v $FLOWS "--userDir" "/data"`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the node-red-docker@1.0.0 start script 'node $NODE_OPTIONS node_modules/node-red/red.js -v $FLOWS "--userDir" "/data"'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the node-red-docker package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node $NODE_OPTIONS node_modules/node-red/red.js -v $FLOWS "--userDir" "/data"
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs node-red-docker
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls node-red-docker
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /usr/src/node-red/npm-debug.log
```
