### PR TITLE
Add user node-red to dialout group

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -14,6 +14,8 @@ RUN useradd --home-dir /usr/src/node-red --no-create-home node-red \
     && chown -R node-red:node-red /data \
     && chown -R node-red:node-red /usr/src/node-red
 
+RUN usermod -a -G dialout node-red
+
 USER node-red
 
 # package.json contains Node-RED NPM module and node dependencies


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [mailing list](https://groups.google.com/forum/#!forum/node-red) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

This is needed for the Serialport-Node to work properly.
At the moment I do it manually after each update. But I think it would be very convinient for a lot of users to have this baked in. Since the serialport node belongs to the standard nodes of nodered and should work out of the box. New users should be able to directly talk to their serial devices by just adding them to the container with the devies parameter.

See this Issue: https://github.com/node-red/node-red-docker/issues/15

I have created a fork and pushed it to the docker hub with just this small change:
https://hub.docker.com/r/fred92/nodered

I tested it successfully with my docker compose file:
```
version: "2"
services:
  nodered:
    image: fred92/nodered:latest (with useradd dialout)
    #image: nodered/node-red-docker:latest (official, without)
    ports:
      - "9004:1880/tcp"
    restart: always
    volumes:
      - nodered_config:/data
    devices:
      - "/dev/ttyUSB-433:/dev/ttyUSB-433"

```



## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [X] I have added suitable unit tests to cover the new/changed functionality
