### PR TITLE
Updated RPI docker image to node 8

### DIFF
--- a/rpi/Dockerfile
+++ b/rpi/Dockerfile
@@ -1,9 +1,10 @@
-ARG NODE_VERSION=6
-FROM hypriot/rpi-node:${NODE_VERSION}
+ARG NODE_VERSION=8-slim
+FROM arm32v7/node:${NODE_VERSION}
 
 # add support for gpio library
 RUN apt-get update
-RUN apt-get install python-rpi.gpio
+RUN apt-get install -y python python-pip
+RUN python -m pip install RPi.GPIO
 
 # Home directory for Node-RED application source code.
 RUN mkdir -p /usr/src/node-red


### PR DESCRIPTION
## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

The RPI image is having issues with different palette's due to running an old node version.

The current base image hypriot/rpi-node is deprecated and doesn't support newer node versions.
I have updated the Docker base image to the official arm32v7 node repo and updated node to version 8 which is the recommended version.

## Checklist
- [ x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
