### PR TITLE
Switch rpi base image to arm32v7/node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+qemu-arm-static

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - source version.sh
   - echo $VERSION
   - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+  - curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/v2.5.0/x86_64_qemu-arm-static.tar.xz | tar -xJ
   - docker build -f latest/Dockerfile -t nodered/node-red-docker .
   - docker build -f latest/Dockerfile -t nodered/node-red-docker:v8 --build-arg NODE_VERSION=8 .
   - docker build -f slim/Dockerfile -t nodered/node-red-docker:slim .

--- a/build-rpi.sh
+++ b/build-rpi.sh
@@ -4,36 +4,43 @@ if [ $# -ne 1 ]; then
 fi
 
 NODE_RED_VERSION=$1
+IMAGE_ORG=${IMAGE_ORG:-nodered}
 
-docker build -f rpi/Dockerfile -t nodered/node-red-docker:rpi .
+# install qemu to build native arm packages
+if [ $(uname) != Darwin ]; then
+    docker run --rm --privileged multiarch/qemu-user-static:register --reset
+fi
+curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/v2.5.0/x86_64_qemu-arm-static.tar.xz | tar -xJ
+
+docker build -f rpi/Dockerfile -t ${IMAGE_ORG}/node-red-docker:rpi .
 
 if [ $? -ne 0 ]; then
     echo "ERROR: Docker build failed for rpi image"
     exit 1
 fi
 
-docker tag nodered/node-red-docker:rpi nodered/node-red-docker:$NODE_RED_VERSION-rpi
+docker tag ${IMAGE_ORG}/node-red-docker:rpi ${IMAGE_ORG}/node-red-docker:$NODE_RED_VERSION-rpi
 
 if [ $? -ne 0 ]; then
     echo "ERROR: Docker tag failed for rpi image"
     exit 1
 fi
 
-docker run -d nodered/node-red-docker:rpi
+docker run -d ${IMAGE_ORG}/node-red-docker:rpi
 
 if [ $? -ne 0 ]; then
     echo "ERROR: Docker container failed to start for rpi build."
     exit 1
 fi
 
-docker push nodered/node-red-docker:rpi
+docker push ${IMAGE_ORG}/node-red-docker:rpi
 
 if [ $? -ne 0 ]; then
     echo "ERROR: Docker push failed for rpi image."
     exit 1
 fi
 
-docker push nodered/node-red-docker:$NODE_RED_VERSION-rpi
+docker push ${IMAGE_ORG}/node-red-docker:$NODE_RED_VERSION-rpi
 
 if [ $? -ne 0 ]; then
     echo "ERROR: Docker push failed for rpi image."

--- a/rpi/Dockerfile
+++ b/rpi/Dockerfile
@@ -1,7 +1,11 @@
 ARG NODE_VERSION=6
-FROM hypriot/rpi-node:${NODE_VERSION}
+FROM arm32v7/node:${NODE_VERSION}
+
+COPY qemu-arm-static /usr/bin
 
 # add support for gpio library
+RUN echo "deb http://archive.raspberrypi.org/debian/ stretch main" > /etc/apt/sources.list.d/raspberrypi.list
+RUN wget https://archive.raspberrypi.org/debian/raspberrypi.gpg.key -O - | apt-key add -
 RUN apt-get update
 RUN apt-get install python-rpi.gpio
 


### PR DESCRIPTION
- Move from deprecated hypriot/rpi-node image to arm32v7/node.
- Build image with real arm architecture (the old image still had amd64 set although it had arm binaries.