### PR TITLE
Dockerfile for ARM64v8 support for Node-RED

### DIFF
--- a/arm64v8/Dockerfile
+++ b/arm64v8/Dockerfile
@@ -1,0 +1,30 @@
+FROM arm64v8/node:8-slim
+
+# Experimental ARM64v8 support for Node-RED
+
+# Home directory for Node-RED application source code.
+RUN mkdir -p /usr/src/node-red
+
+# User data directory, contains flows, config and nodes.
+RUN mkdir /data
+
+WORKDIR /usr/src/node-red
+
+# Add node-red user so we aren't running as root.
+RUN useradd --home-dir /usr/src/node-red --no-create-home node-red \
+    && chown -R node-red:node-red /data \
+    && chown -R node-red:node-red /usr/src/node-red
+
+USER node-red
+
+# package.json contains Node-RED NPM module and node dependencies
+COPY package.json /usr/src/node-red/
+RUN npm install
+
+# User configuration directory volume
+EXPOSE 1880
+
+# Environment variable holding file path for flows configuration
+ENV FLOWS=flows.json
+
+CMD ["npm", "start", "--", "--userDir", "/data"]


### PR DESCRIPTION
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed changes

This just adds support for ARM64v8 Docker.

The new Dockerfile is based in the current ARMv8 Dockerfile, the only change is the base image has been changed to "arm64v8/node:8-slim"

This has been tested successfully on a NanoPi NEO 2

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [x] I have added suitable unit tests to cover the new/changed functionality
