### PR TITLE
Add QEMU multiarch support for rpi images (current images on DockerHub are only amd64 compatible)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ before_install:
   - docker run --rm --privileged multiarch/qemu-user-static:register --reset
   - curl -sLO https://github.com/multiarch/qemu-user-static/releases/download/v4.0.0/qemu-arm-static.tar.gz
   - tar -xzvf qemu-arm-static.tar.gz
-  - curl -sLO https://github.com/multiarch/qemu-user-static/releases/download/v4.0.0/qemu-aarch64-static.tar.gz
-  - tar -xzvf qemu-aarch64-static.tar.gz
   - docker build -f latest/Dockerfile -t nodered/node-red-docker .
   - docker build -f latest/Dockerfile -t nodered/node-red-docker:v10 --build-arg NODE_VERSION=10 .
   - docker build -f slim/Dockerfile -t nodered/node-red-docker:slim .

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ before_install:
   - source version.sh
   - echo $VERSION
   - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+  - curl -sLO https://github.com/multiarch/qemu-user-static/releases/download/v4.0.0/qemu-arm-static.tar.gz
+  - tar -xzvf qemu-arm-static.tar.gz
+  - curl -sLO https://github.com/multiarch/qemu-user-static/releases/download/v4.0.0/qemu-aarch64-static.tar.gz
+  - tar -xzvf qemu-aarch64-static.tar.gz
   - docker build -f latest/Dockerfile -t nodered/node-red-docker .
   - docker build -f latest/Dockerfile -t nodered/node-red-docker:v10 --build-arg NODE_VERSION=10 .
   - docker build -f slim/Dockerfile -t nodered/node-red-docker:slim .

--- a/rpi/Dockerfile
+++ b/rpi/Dockerfile
@@ -1,6 +1,9 @@
 ARG NODE_VERSION=8
 FROM hypriot/rpi-node:${NODE_VERSION}
 
+# Add QEMU to enable multi-arch builds on travis
+COPY qemu-arm-static  /usr/bin/
+
 # add support for gpio library
 RUN apt-get update
 RUN apt-get install python-rpi.gpio


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.
-->

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes
This change adds the arm qemu-user-static binary to the rpi image before any commands are run.  This change allows for cross-building the docker rpi image on travis.  Currently every image I've tried to pull from docker hub has been only compatible with amd64 (even the rpi images which should be compatible)

Please let me know if I'm not following the process properly, this is my first PR and I think this solves the issue I've observed and the builds still pass on travis.
<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
