### PR TITLE
Use official arm32v7/node RaspberryPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following images are built for each Node-RED release, using a Node.js v8 bas
 
 - **latest** - uses [official Node.JS v8 base image](https://hub.docker.com/_/node/).
 - **slim** uses [Alpine Linux base image](https://hub.docker.com/r/mhart/alpine-node/).
-- **rpi** uses [RPi-compatible base image](https://hub.docker.com/r/hypriot/rpi-node/).
+- **rpi** uses [Official arm32v7 Raspberry Pi base image](https://hub.docker.com/r/arm32v7/node).
 
 Using Alpine Linux reduces the built image size (~100MB vs ~700MB) but removes
 standard dependencies that are required for native module compilation. If you

--- a/rpi/Dockerfile
+++ b/rpi/Dockerfile
@@ -1,34 +1,48 @@
 ARG NODE_VERSION=8
-FROM hypriot/rpi-node:${NODE_VERSION}
+FROM arm32v7/node:${NODE_VERSION}-stretch-slim
 
-# add support for gpio library
-RUN apt-get update
-RUN apt-get install python-rpi.gpio
+# Install the base requirements
+RUN apt-get update \
+    && apt-get dist-upgrade -y \
+    && apt-get install -y python python-pip \
+    && pip install RPi.GPIO \
+    && npm install -g --unsafe-perm npm
 
-# Home directory for Node-RED application source code.
-RUN mkdir -p /usr/src/node-red
-
-# User data directory, contains flows, config and nodes.
-RUN mkdir /data
-
+# Set the Docker working directory for Node-RED
 WORKDIR /usr/src/node-red
 
 # Add node-red user so we aren't running as root.
-RUN useradd --home-dir /usr/src/node-red --no-create-home node-red \
-    && chown -R node-red:node-red /data \
-    && chown -R node-red:node-red /usr/src/node-red
-
-USER node-red
+RUN mkdir -p /data \
+    && mkdir -p /usr/src/node-red \
+    && useradd --home-dir /usr/src/node-red --no-create-home node-red
 
 # package.json contains Node-RED NPM module and node dependencies
 COPY package.json /usr/src/node-red/
-RUN npm install
 
-# User configuration directory volume
+# Install Node-RED
+RUN cd /usr/src/node-red/ \
+    && npm install \
+    && npm install -g --unsafe-perm node-red-admin
+
+# Clean-up
+RUN apt-get clean -y \
+    && apt-get autoclean -y \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set ownership permissions
+RUN chown -R node-red:node-red /data \
+    && chown -R node-red:node-red /usr/src/node-red
+
+# Node-RED default un-encrypted TCP port for HTTP
 EXPOSE 1880
+
+# Run Node-RED as user node-red (not as root)
+USER node-red
 
 # Environment variable holding file path for flows configuration
 ENV FLOWS=flows.json
 ENV NODE_PATH=/usr/src/node-red/node_modules:/data/node_modules
 
+# Start Node-RED
 CMD ["npm", "start", "--", "--userDir", "/data"]


### PR DESCRIPTION
## Types of changes
- [x ] Bugfix (non-breaking change which fixes an issue)

## Proposed changes
- This is a drop-in replacement for the Docker base image for the Raspberry Pi (arm32v7)
- The [current base image is deprecated](https://hub.docker.com/r/hypriot/rpi-node/)
- The [new base image is officially supported](https://hub.docker.com/r/arm32v7/node)
- No functionality changes

## Checklist
- [x ] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
