### PR TITLE
Added env SAVE_MODE

### DIFF
--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -83,6 +83,7 @@ COPY --from=build /usr/src/node-red/prod_node_modules ./node_modules
 ENV NODE_RED_VERSION=$NODE_RED_VERSION
 ENV FLOWS=flows.json
 ENV NODE_PATH=/usr/src/node-red/node_modules:/data/node_modules
+ENV SAVE_MODE=""
 
 # User configuration directory volume
 VOLUME ["/data"]
@@ -90,4 +91,4 @@ VOLUME ["/data"]
 # Expose the listening port of node-red
 EXPOSE 1880
 
-ENTRYPOINT ["npm", "start", "--", "--userDir", "/data"]
+ENTRYPOINT npm start -- --userDir /data $SAVE_MODE


### PR DESCRIPTION
Added an env to set save mode argument

usage:

```shell
docker run -it -p1880:1880 -e SAVE_MODE=--safe --name mynodered nodered/node-red:latest
```

solves [#102](https://github.com/node-red/node-red-docker/issues/102)
