### PR TITLE
Feature/development repo

### DIFF
--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -26,8 +26,11 @@ main() {
   "manifest-list-version")
     docker_manifest_list_version "$2" "$3"
     ;;
-  "manifest-list-test-beta-latest")
-    docker_manifest_list_test_beta_latest "$2" "$3"
+  "manifest_list_dev_test_edge_beta")
+    docker_manifest_list_dev_test_edge_beta "$2" "$3"
+    ;;
+  "manifest_list_beta_latest")
+    docker_manifest_list_beta_latest "$2" "$3"
     ;;
   *)
     echo "none of above!"
@@ -127,11 +130,43 @@ function docker_manifest_list_version() {
   docker run --rm mplatform/mquery ${TARGET}:${BUILD_VERSION}${NODE_VERSION}${TAG_SUFFIX}
 }
 
-function docker_manifest_list_test_beta_latest() {
+function docker_manifest_list_dev_test_edge_beta() {
 
-  if [[ ${BUILD_VERSION} == *"test"* ]]; then
+  if [[ ${BUILD_VERSION} == *"dev"* ]]; then
+    export TAG_PREFIX="dev";
+  elif [[ ${BUILD_VERSION} == *"test"* ]]; then
     export TAG_PREFIX="test";
-  elif [[ ${BUILD_VERSION} == *"beta"* ]]; then
+  elif [[ ${BUILD_VERSION} == *"edge"* ]]; then
+    export TAG_PREFIX="edge";
+  else
+    export TAG_PREFIX="beta";
+  fi
+
+  if [[ ${1} == "" ]]; then export NODE_VERSION=""; else export NODE_VERSION="-${1}"; fi
+  if [[ ${2} == "default" ]]; then export TAG_SUFFIX=""; else export TAG_SUFFIX="-${2}"; fi
+
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}."
+
+  docker manifest create ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-amd64 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x
+
+  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 --os=linux --arch=arm --variant=v6
+  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 --os=linux --arch=arm --variant=v7
+  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
+  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x   --os=linux --arch=s390x
+
+  docker manifest push ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}
+  
+  docker run --rm mplatform/mquery ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}
+}
+
+function docker_manifest_list_beta_latest() {
+
+  if [[ ${BUILD_VERSION} == *"beta"* ]]; then
     export TAG_PREFIX="beta";
   else
     export TAG_PREFIX="latest";
@@ -155,7 +190,7 @@ function docker_manifest_list_test_beta_latest() {
   docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x   --os=linux --arch=s390x
 
   docker manifest push ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}
-  
+
   docker run --rm mplatform/mquery ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}
 }
 

--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -26,11 +26,14 @@ main() {
   "manifest-list-version")
     docker_manifest_list_version "$2" "$3"
     ;;
-  "manifest_list_dev_test_edge_beta")
-    docker_manifest_list_dev_test_edge_beta "$2" "$3"
+  "manifest_list_beta")
+    docker_manifest_list_beta "$2" "$3"
     ;;
-  "manifest_list_beta_latest")
-    docker_manifest_list_beta_latest "$2" "$3"
+  "manifest_list_branch")
+    docker_manifest_list_branch "$2" "$3"
+    ;;
+  "manifest_list_latest")
+    docker_manifest_list_latest "$2" "$3"
     ;;
   *)
     echo "none of above!"
@@ -130,68 +133,73 @@ function docker_manifest_list_version() {
   docker run --rm mplatform/mquery ${TARGET}:${BUILD_VERSION}${NODE_VERSION}${TAG_SUFFIX}
 }
 
-function docker_manifest_list_dev_test_edge_beta() {
-
-  if [[ ${BUILD_VERSION} == *"dev"* ]]; then
-    export TAG_PREFIX="dev";
-  elif [[ ${BUILD_VERSION} == *"test"* ]]; then
-    export TAG_PREFIX="test";
-  elif [[ ${BUILD_VERSION} == *"edge"* ]]; then
-    export TAG_PREFIX="edge";
-  else
-    export TAG_PREFIX="beta";
-  fi
-
+function docker_manifest_list_beta() {
   if [[ ${1} == "" ]]; then export NODE_VERSION=""; else export NODE_VERSION="-${1}"; fi
   if [[ ${2} == "default" ]]; then export TAG_SUFFIX=""; else export TAG_SUFFIX="-${2}"; fi
 
-  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}."
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX}."
 
-  docker manifest create ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} \
+  docker manifest create ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX} \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-amd64 \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x
 
-  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 --os=linux --arch=arm --variant=v6
-  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 --os=linux --arch=arm --variant=v7
-  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
-  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x   --os=linux --arch=s390x
+  docker manifest annotate ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 --os=linux --arch=arm --variant=v6
+  docker manifest annotate ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 --os=linux --arch=arm --variant=v7
+  docker manifest annotate ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
+  docker manifest annotate ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x   --os=linux --arch=s390x
 
-  docker manifest push ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}
+  docker manifest push ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX}
   
-  docker run --rm mplatform/mquery ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}
+  docker run --rm mplatform/mquery ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX}
 }
 
-function docker_manifest_list_beta_latest() {
-
-  if [[ ${BUILD_VERSION} == *"beta"* ]]; then
-    export TAG_PREFIX="beta";
-  else
-    export TAG_PREFIX="latest";
-  fi
-
+function docker_manifest_list_branch() {
   if [[ ${1} == "" ]]; then export NODE_VERSION=""; else export NODE_VERSION="-${1}"; fi
   if [[ ${2} == "default" ]]; then export TAG_SUFFIX=""; else export TAG_SUFFIX="-${2}"; fi
 
-  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}."
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${TRAVIS_BRANCH}${NODE_VERSION}${TAG_SUFFIX}."
 
-  docker manifest create ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} \
+  docker manifest create ${TARGET}:${TRAVIS_BRANCH}${NODE_VERSION}${TAG_SUFFIX} \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-amd64 \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x
 
-  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 --os=linux --arch=arm --variant=v6
-  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 --os=linux --arch=arm --variant=v7
-  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
-  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x   --os=linux --arch=s390x
+  docker manifest annotate ${TARGET}:${TRAVIS_BRANCH}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 --os=linux --arch=arm --variant=v6
+  docker manifest annotate ${TARGET}:${TRAVIS_BRANCH}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 --os=linux --arch=arm --variant=v7
+  docker manifest annotate ${TARGET}:${TRAVIS_BRANCH}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
+  docker manifest annotate ${TARGET}:${TRAVIS_BRANCH}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x   --os=linux --arch=s390x
 
-  docker manifest push ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}
+  docker manifest push ${TARGET}:${TRAVIS_BRANCH}${NODE_VERSION}${TAG_SUFFIX}
 
-  docker run --rm mplatform/mquery ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}
+  docker run --rm mplatform/mquery ${TARGET}:${TRAVIS_BRANCH}${NODE_VERSION}${TAG_SUFFIX}
+}
+
+function docker_manifest_list_latest() {
+  if [[ ${1} == "" ]]; then export NODE_VERSION=""; else export NODE_VERSION="-${1}"; fi
+  if [[ ${2} == "default" ]]; then export TAG_SUFFIX=""; else export TAG_SUFFIX="-${2}"; fi
+
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX}."
+
+  docker manifest create ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX} \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-amd64 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x
+
+  docker manifest annotate ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 --os=linux --arch=arm --variant=v6
+  docker manifest annotate ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 --os=linux --arch=arm --variant=v7
+  docker manifest annotate ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
+  docker manifest annotate ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x   --os=linux --arch=s390x
+
+  docker manifest push ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX}
+
+  docker run --rm mplatform/mquery ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX}
 }
 
 function setup_dependencies() {

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,9 +125,9 @@ jobs:
                   ./.docker/docker.sh manifest_list_latest "" "minimal"
 
                   # Create and push manifest list `latest` for default
-                  - ./.docker/docker.sh manifest_list_latest "12" "default"
-                  - ./.docker/docker.sh manifest_list_latest "10" "default"
-                  - ./.docker/docker.sh manifest_list_latest "" "default"
+                  ./.docker/docker.sh manifest_list_latest "12" "default"
+                  ./.docker/docker.sh manifest_list_latest "10" "default"
+                  ./.docker/docker.sh manifest_list_latest "" "default"
 
                 elif [[ "${TRAVIS_BRANCH}" == "dev" ] && [ "${TRAVIS_TAG}" =~ "beta" ]]; then
                   # Create and push manifest list `beta` for minimal
@@ -136,9 +136,9 @@ jobs:
                   ./.docker/docker.sh manifest_list_beta "" "minimal"
 
                   # Create and push manifest list `beta` for default
-                  - ./.docker/docker.sh manifest_list_beta "12" "default"
-                  - ./.docker/docker.sh manifest_list_beta "10" "default"
-                  - ./.docker/docker.sh manifest_list_beta "" "default"
+                  ./.docker/docker.sh manifest_list_beta "12" "default"
+                  ./.docker/docker.sh manifest_list_beta "10" "default"
+                  ./.docker/docker.sh manifest_list_beta "" "default"
 
                 else
                   # Create and push manifest list `branch` for minimal
@@ -147,9 +147,9 @@ jobs:
                   ./.docker/docker.sh manifest_list_branch "" "minimal"
 
                   # Create and push manifest list `branch` for default
-                  - ./.docker/docker.sh manifest_list_branch "12" "default"
-                  - ./.docker/docker.sh manifest_list_branch "10" "default"
-                  - ./.docker/docker.sh manifest_list_branch "" "default"
+                  ./.docker/docker.sh manifest_list_branch "12" "default"
+                  ./.docker/docker.sh manifest_list_branch "10" "default"
+                  ./.docker/docker.sh manifest_list_branch "" "default"
                 fi
 
               # Docker Logout

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_script:
     if [[ "${TRAVIS_BRANCH}" == "master" ]]; then
       export TARGET=nodered/node-red
     else
-      export TARGET=nodered/node-red-edge
+      export TARGET=nodered/node-red-dev
     fi
 
   # Set BUILD_VERSION
@@ -112,15 +112,33 @@ jobs:
               - ./.docker/docker.sh manifest-list-version "10" "default"
               - ./.docker/docker.sh manifest-list-version "" "default"
 
-              # Create and push manifest list 'latest' or 'testing' for minimal
-              - ./.docker/docker.sh manifest-list-test-beta-latest "12" "minimal"
-              - ./.docker/docker.sh manifest-list-test-beta-latest "10" "minimal"
-              - ./.docker/docker.sh manifest-list-test-beta-latest "" "minimal"
+              # Tags with either `dev`, `test`, `edge` or `beta` get manifest listed and pushed to `nodered/node-red-dev`
+              - >
+                if [[ "${TRAVIS_BRANCH}" == "dev" ]]; then
+                  # Create and push manifest list `dev`, `test`, `edge` or `beta` for minimal
+                  ./.docker/docker.sh manifest_list_dev_test_edge_beta_latest "12" "minimal"
+                  ./.docker/docker.sh manifest_list_dev_test_edge_beta_latest "10" "minimal"
+                  ./.docker/docker.sh manifest_list_dev_test_edge_beta_latest "" "minimal"
 
-              # Create and push manifest list 'latest' or 'testing' for default
-              - ./.docker/docker.sh manifest-list-test-beta-latest "12" "default"
-              - ./.docker/docker.sh manifest-list-test-beta-latest "10" "default"
-              - ./.docker/docker.sh manifest-list-test-beta-latest "" "default"
+                  # Create and push manifest list `dev`, `test`, `edge` or `beta` for default
+                  - ./.docker/docker.sh manifest_list_dev_test_edge_beta_latest "12" "default"
+                  - ./.docker/docker.sh manifest_list_dev_test_edge_beta_latest "10" "default"
+                  - ./.docker/docker.sh manifest_list_dev_test_edge_beta_latest "" "default"
+                fi
+
+              # Tags with either `beta` or none of these (in case of a final) get manifest listed and pushed to `nodered/node-red`
+              - >
+                if [[ "${TRAVIS_BRANCH}" == "master" ]]; then
+                 # Create and push manifest list `beta` or `latest` for minimal
+                 ./.docker/docker.sh manifest_list_beta_latest "12" "minimal"
+                 ./.docker/docker.sh manifest_list_beta_latest "10" "minimal"
+                 ./.docker/docker.sh manifest_list_beta_latest "" "minimal"
+
+                 # Create and push manifest list `beta` or `latest` for default
+                 - ./.docker/docker.sh manifest_list_beta_latest "12" "default"
+                 - ./.docker/docker.sh manifest_list_beta_latest "10" "default"
+                 - ./.docker/docker.sh manifest_list_beta_latest "" "default"
+                fi
 
               # Docker Logout
               - docker logout

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
 install: true
 
 before_script:
-  # Set TARGET
+  # Set TARGET Docker repo
   - >
     if [[ "${TRAVIS_BRANCH}" == "master" ]]; then
       export TARGET=nodered/node-red
@@ -57,15 +57,17 @@ before_script:
       export TARGET=nodered/node-red-dev
     fi
 
+  # Set NODE_RED_VERSION from package.json
+  - >
+    export NODE_RED_VERSION=$(grep -oE "\"node-red\": \"(\w*.\w*.\w*.\w*.\w*.)" package.json | cut -d\" -f4)
+
   # Set BUILD_VERSION
   - >
     if [ ! -z "${TRAVIS_TAG}" ]; then
       export BUILD_VERSION=${TRAVIS_TAG:1};
+    else
+      export BUILD_VERSION=${NODE_RED_VERSION}-${TRAVIS_BRANCH}
     fi
-
-  # Set NODE_RED_VERSION from package.json
-  - >
-    export NODE_RED_VERSION=$(grep -oE "\"node-red\": \"(\w*.\w*.\w*.\w*.\w*.)" package.json | cut -d\" -f4)
 
 script:
   # Build Docker image
@@ -74,27 +76,27 @@ script:
   # Test Docker image
   - ./.docker/docker.sh test
 
-  # Push Docker image, ony if TRAVIS_TAG is set
+  # Push Docker image, only for non TRAVIS_PULL_REQUEST
   - >
-    if [ ! -z "${TRAVIS_TAG}" ]; then
-      # Tag Docker image
-      ./.docker/docker.sh tag
+    if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+        # Tag Docker image
+        ./.docker/docker.sh tag
 
-      # Docker Login
-      echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+        # Docker Login
+        echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 
-      # Push Docker image
-      ./.docker/docker.sh push
+        # Push Docker image
+        ./.docker/docker.sh push
 
-      # Docker Logout
-      docker logout
+        # Docker Logout
+        docker logout
     fi
 
 jobs:
     include:
         - stage: manifest
-          # Only create and push manifest list to Docker Hub, when tag starts with a `v`, eg. v0.20.8
-          if: tag =~ ^v
+          # Only create and push manifest list to Docker Hub, when non PULL_REQUEST
+          if: type != pull_request
           script:
               # Create and push Docker manifest lists
               # The push order is displayed in reverse order on Docker Hub
@@ -112,32 +114,42 @@ jobs:
               - ./.docker/docker.sh manifest-list-version "10" "default"
               - ./.docker/docker.sh manifest-list-version "" "default"
 
-              # Tags with either `dev`, `test`, `edge` or `beta` get manifest listed and pushed to `nodered/node-red-dev`
+              # Tags starting with `v` and the origin is master branch get manifest listed as `latest` and push to `nodered/node-red`
+              # Tags containing `beta` get manifest listed as `beta` and pushed to `nodered/node-red-dev`
+              # Any branch get manifest listed as branch and pushed to `nodered/node-red-dev`
               - >
-                if [[ "${TRAVIS_BRANCH}" == "dev" ]]; then
-                  # Create and push manifest list `dev`, `test`, `edge` or `beta` for minimal
-                  ./.docker/docker.sh manifest_list_dev_test_edge_beta_latest "12" "minimal"
-                  ./.docker/docker.sh manifest_list_dev_test_edge_beta_latest "10" "minimal"
-                  ./.docker/docker.sh manifest_list_dev_test_edge_beta_latest "" "minimal"
+                if [[ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_TAG}" == "v*" ]]; then
+                  # Create and push manifest list `latest` for minimal
+                  ./.docker/docker.sh manifest_list_latest "12" "minimal"
+                  ./.docker/docker.sh manifest_list_latest "10" "minimal"
+                  ./.docker/docker.sh manifest_list_latest "" "minimal"
 
-                  # Create and push manifest list `dev`, `test`, `edge` or `beta` for default
-                  - ./.docker/docker.sh manifest_list_dev_test_edge_beta_latest "12" "default"
-                  - ./.docker/docker.sh manifest_list_dev_test_edge_beta_latest "10" "default"
-                  - ./.docker/docker.sh manifest_list_dev_test_edge_beta_latest "" "default"
-                fi
+                  # Create and push manifest list `latest` for default
+                  - ./.docker/docker.sh manifest_list_latest "12" "default"
+                  - ./.docker/docker.sh manifest_list_latest "10" "default"
+                  - ./.docker/docker.sh manifest_list_latest "" "default"
 
-              # Tags with either `beta` or none of these (in case of a final) get manifest listed and pushed to `nodered/node-red`
-              - >
-                if [[ "${TRAVIS_BRANCH}" == "master" ]]; then
-                 # Create and push manifest list `beta` or `latest` for minimal
-                 ./.docker/docker.sh manifest_list_beta_latest "12" "minimal"
-                 ./.docker/docker.sh manifest_list_beta_latest "10" "minimal"
-                 ./.docker/docker.sh manifest_list_beta_latest "" "minimal"
+                elif [[ "${TRAVIS_BRANCH}" == "dev" ] && [ "${TRAVIS_TAG}" =~ "beta" ]]; then
+                  # Create and push manifest list `beta` for minimal
+                  ./.docker/docker.sh manifest_list_beta "12" "minimal"
+                  ./.docker/docker.sh manifest_list_beta "10" "minimal"
+                  ./.docker/docker.sh manifest_list_beta "" "minimal"
 
-                 # Create and push manifest list `beta` or `latest` for default
-                 - ./.docker/docker.sh manifest_list_beta_latest "12" "default"
-                 - ./.docker/docker.sh manifest_list_beta_latest "10" "default"
-                 - ./.docker/docker.sh manifest_list_beta_latest "" "default"
+                  # Create and push manifest list `beta` for default
+                  - ./.docker/docker.sh manifest_list_beta "12" "default"
+                  - ./.docker/docker.sh manifest_list_beta "10" "default"
+                  - ./.docker/docker.sh manifest_list_beta "" "default"
+
+                else
+                  # Create and push manifest list `branch` for minimal
+                  ./.docker/docker.sh manifest_list_branch "12" "minimal"
+                  ./.docker/docker.sh manifest_list_branch "10" "minimal"
+                  ./.docker/docker.sh manifest_list_branch "" "minimal"
+
+                  # Create and push manifest list `branch` for default
+                  - ./.docker/docker.sh manifest_list_branch "12" "default"
+                  - ./.docker/docker.sh manifest_list_branch "10" "default"
+                  - ./.docker/docker.sh manifest_list_branch "" "default"
                 fi
 
               # Docker Logout

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ language: bash
 
 env:
   global:
-    - TARGET=nodered/node-red
     - QEMU_VERSION=v4.0.0
     - OS=alpine
     - DOCKER_FILE=Dockerfile.alpine
@@ -50,6 +49,14 @@ before_install:
 install: true
 
 before_script:
+  # Set TARGET
+  - >
+    if [[ "${TRAVIS_BRANCH}" == "master" ]]; then
+      export TARGET=nodered/node-red
+    else
+      export TARGET=nodered/node-red-edge
+    fi
+
   # Set BUILD_VERSION
   - >
     if [ ! -z "${TRAVIS_TAG}" ]; then


### PR DESCRIPTION
This feature adds the possibility to `release` images and there manifest list to a new docker repo `nodered/node-red-dev`, so they can be tested before releasing to `nodered/node-red`.

- Github tags with either `dev`, `test`, `edge` or `beta` get manifest listed and pushed to `nodered/node-red-dev`

- Github tags with either `beta` or none of these (in case of a final) get manifest listed and pushed to `nodered/node-red`

Which github tag to use depends on the change and goal of releasing