### PR TITLE
Add openSSL

### DIFF
--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -90,4 +90,7 @@ VOLUME ["/data"]
 # Expose the listening port of node-red
 EXPOSE 1880
 
+# Add a healthcheck (default every 30 secs)
+HEALTHCHECK CMD curl http://localhost:1880/ || exit 1
+
 ENTRYPOINT ["npm", "start", "--", "--userDir", "/data"]

--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -21,6 +21,7 @@ RUN set -ex && \
         curl \
         nano \
         git \
+        openssl \
         openssh-client && \
     mkdir -p /usr/src/node-red /data && \
     deluser --remove-home node && \

--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -26,8 +26,17 @@ main() {
   "manifest-list-version")
     docker_manifest_list_version "$2" "$3"
     ;;
-  "manifest-list-test-beta-latest")
-    docker_manifest_list_test_beta_latest "$2" "$3"
+  "manifest_list_beta")
+    docker_manifest_list_beta "$2" "$3"
+    ;;
+  "manifest_list_dev")
+    docker_manifest_list_dev "$2" "$3"
+    ;;
+  "manifest_list_test")
+    docker_manifest_list_test "$2" "$3"
+    ;;
+  "manifest_list_latest")
+    docker_manifest_list_latest "$2" "$3"
     ;;
   *)
     echo "none of above!"
@@ -115,48 +124,118 @@ function docker_manifest_list_version() {
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 \
-    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-i386
 
-  docker manifest annotate ${TARGET}:${BUILD_VERSION}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 --os=linux --arch=arm --variant=v6
-  docker manifest annotate ${TARGET}:${BUILD_VERSION}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 --os=linux --arch=arm --variant=v7
+  docker manifest annotate ${TARGET}:${BUILD_VERSION}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 --os=linux --arch=arm   --variant=v6
+  docker manifest annotate ${TARGET}:${BUILD_VERSION}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 --os=linux --arch=arm   --variant=v7
   docker manifest annotate ${TARGET}:${BUILD_VERSION}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
   docker manifest annotate ${TARGET}:${BUILD_VERSION}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x   --os=linux --arch=s390x
+  docker manifest annotate ${TARGET}:${BUILD_VERSION}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-i386    --os=linux --arch=386
 
   docker manifest push ${TARGET}:${BUILD_VERSION}${NODE_VERSION}${TAG_SUFFIX}
   
   docker run --rm mplatform/mquery ${TARGET}:${BUILD_VERSION}${NODE_VERSION}${TAG_SUFFIX}
 }
 
-function docker_manifest_list_test_beta_latest() {
-
-  if [[ ${BUILD_VERSION} == *"test"* ]]; then
-    export TAG_PREFIX="test";
-  elif [[ ${BUILD_VERSION} == *"beta"* ]]; then
-    export TAG_PREFIX="beta";
-  else
-    export TAG_PREFIX="latest";
-  fi
-
+function docker_manifest_list_beta() {
   if [[ ${1} == "" ]]; then export NODE_VERSION=""; else export NODE_VERSION="-${1}"; fi
   if [[ ${2} == "default" ]]; then export TAG_SUFFIX=""; else export TAG_SUFFIX="-${2}"; fi
 
-  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}."
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX}."
 
-  docker manifest create ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} \
+  docker manifest create ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX} \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-amd64 \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 \
     ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 \
-    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-i386
 
-  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 --os=linux --arch=arm --variant=v6
-  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 --os=linux --arch=arm --variant=v7
-  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
-  docker manifest annotate ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x   --os=linux --arch=s390x
+  docker manifest annotate ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 --os=linux --arch=arm   --variant=v6
+  docker manifest annotate ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 --os=linux --arch=arm   --variant=v7
+  docker manifest annotate ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
+  docker manifest annotate ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x   --os=linux --arch=s390x
+  docker manifest annotate ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-i386    --os=linux --arch=386
 
-  docker manifest push ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}
-  
-  docker run --rm mplatform/mquery ${TARGET}:${TAG_PREFIX}${NODE_VERSION}${TAG_SUFFIX}
+  docker manifest push ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX}
+
+  docker run --rm mplatform/mquery ${TARGET}:beta${NODE_VERSION}${TAG_SUFFIX}
+}
+
+function docker_manifest_list_dev() {
+  if [[ ${1} == "" ]]; then export NODE_VERSION=""; else export NODE_VERSION="-${1}"; fi
+  if [[ ${2} == "default" ]]; then export TAG_SUFFIX=""; else export TAG_SUFFIX="-${2}"; fi
+
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:dev${NODE_VERSION}${TAG_SUFFIX}."
+
+  docker manifest create ${TARGET}:dev${NODE_VERSION}${TAG_SUFFIX} \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-amd64 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-i386
+
+  docker manifest annotate ${TARGET}:dev${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 --os=linux --arch=arm   --variant=v6
+  docker manifest annotate ${TARGET}:dev${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 --os=linux --arch=arm   --variant=v7
+  docker manifest annotate ${TARGET}:dev${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
+  docker manifest annotate ${TARGET}:dev${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x   --os=linux --arch=s390x
+  docker manifest annotate ${TARGET}:dev${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-i386    --os=linux --arch=386
+
+  docker manifest push ${TARGET}:dev${NODE_VERSION}${TAG_SUFFIX}
+
+  docker run --rm mplatform/mquery ${TARGET}:dev${NODE_VERSION}${TAG_SUFFIX}
+}
+
+function docker_manifest_list_test() {
+  if [[ ${1} == "" ]]; then export NODE_VERSION=""; else export NODE_VERSION="-${1}"; fi
+  if [[ ${2} == "default" ]]; then export TAG_SUFFIX=""; else export TAG_SUFFIX="-${2}"; fi
+
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:test${NODE_VERSION}${TAG_SUFFIX}."
+
+  docker manifest create ${TARGET}:test${NODE_VERSION}${TAG_SUFFIX} \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-amd64 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-i386
+
+  docker manifest annotate ${TARGET}:test${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 --os=linux --arch=arm   --variant=v6
+  docker manifest annotate ${TARGET}:test${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 --os=linux --arch=arm   --variant=v7
+  docker manifest annotate ${TARGET}:test${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
+  docker manifest annotate ${TARGET}:test${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x   --os=linux --arch=s390x
+  docker manifest annotate ${TARGET}:test${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-i386    --os=linux --arch=386
+
+  docker manifest push ${TARGET}:test${NODE_VERSION}${TAG_SUFFIX}
+
+  docker run --rm mplatform/mquery ${TARGET}:test${NODE_VERSION}${TAG_SUFFIX}
+}
+
+function docker_manifest_list_latest() {
+  if [[ ${1} == "" ]]; then export NODE_VERSION=""; else export NODE_VERSION="-${1}"; fi
+  if [[ ${2} == "default" ]]; then export TAG_SUFFIX=""; else export TAG_SUFFIX="-${2}"; fi
+
+  echo "DOCKER MANIFEST: Create and Push docker manifest list - ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX}."
+
+  docker manifest create ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX} \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-amd64 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x \
+    ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-i386
+
+  docker manifest annotate ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v6 --os=linux --arch=arm   --variant=v6
+  docker manifest annotate ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm32v7 --os=linux --arch=arm   --variant=v7
+  docker manifest annotate ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
+  docker manifest annotate ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-s390x   --os=linux --arch=s390x
+  docker manifest annotate ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX} ${TARGET}:${BUILD_VERSION}${NODE_VERSION:--10}${TAG_SUFFIX}-i386    --os=linux --arch=386
+
+  docker manifest push ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX}
+
+  docker run --rm mplatform/mquery ${TARGET}:latest${NODE_VERSION}${TAG_SUFFIX}
 }
 
 function setup_dependencies() {
@@ -196,6 +275,7 @@ function prepare_qemu() {
     curl -L -o qemu-arm-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-arm-static.tar.gz && tar xzf qemu-arm-static.tar.gz &&
     curl -L -o qemu-aarch64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-aarch64-static.tar.gz && tar xzf qemu-aarch64-static.tar.gz &&
     curl -L -o qemu-s390x-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-s390x-static.tar.gz && tar xzf qemu-s390x-static.tar.gz &&
+    curl -L -o qemu-i386-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-i386-static.tar.gz && tar xzf qemu-i386-static.tar.gz &&
     popd
 }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ language: bash
 
 env:
   global:
-    - TARGET=nodered/node-red
     - QEMU_VERSION=v4.0.0
     - OS=alpine
     - DOCKER_FILE=Dockerfile.alpine
@@ -21,6 +20,7 @@ env:
     - NODE_VERSION=10 TAG_SUFFIX=default QEMU_ARCH=arm     ARCH=arm32v7
     - NODE_VERSION=10 TAG_SUFFIX=default QEMU_ARCH=aarch64 ARCH=arm64v8
     - NODE_VERSION=10 TAG_SUFFIX=default QEMU_ARCH=s390x   ARCH=s390x
+    - NODE_VERSION=10 TAG_SUFFIX=default QEMU_ARCH=i386    ARCH=i386
 
     # Minimal Images
     - NODE_VERSION=10 TAG_SUFFIX=minimal QEMU_ARCH=x86_64  ARCH=amd64
@@ -28,6 +28,7 @@ env:
     - NODE_VERSION=10 TAG_SUFFIX=minimal QEMU_ARCH=arm     ARCH=arm32v7
     - NODE_VERSION=10 TAG_SUFFIX=minimal QEMU_ARCH=aarch64 ARCH=arm64v8
     - NODE_VERSION=10 TAG_SUFFIX=minimal QEMU_ARCH=s390x   ARCH=s390x
+    - NODE_VERSION=10 TAG_SUFFIX=minimal QEMU_ARCH=i386    ARCH=i386
 
     ### Node JS 12 #####################################################################################################
     # Default Images
@@ -36,6 +37,7 @@ env:
     - NODE_VERSION=12 TAG_SUFFIX=default QEMU_ARCH=arm     ARCH=arm32v7
     - NODE_VERSION=12 TAG_SUFFIX=default QEMU_ARCH=aarch64 ARCH=arm64v8
     - NODE_VERSION=12 TAG_SUFFIX=default QEMU_ARCH=s390x   ARCH=s390x
+    - NODE_VERSION=12 TAG_SUFFIX=default QEMU_ARCH=i386    ARCH=i386
 
     # Minimal Images
     - NODE_VERSION=12 TAG_SUFFIX=minimal QEMU_ARCH=x86_64  ARCH=amd64
@@ -43,6 +45,7 @@ env:
     - NODE_VERSION=12 TAG_SUFFIX=minimal QEMU_ARCH=arm     ARCH=arm32v7
     - NODE_VERSION=12 TAG_SUFFIX=minimal QEMU_ARCH=aarch64 ARCH=arm64v8
     - NODE_VERSION=12 TAG_SUFFIX=minimal QEMU_ARCH=s390x   ARCH=s390x
+    - NODE_VERSION=12 TAG_SUFFIX=minimal QEMU_ARCH=i386    ARCH=i386
 
 before_install:
   - ./.docker/docker.sh prepare
@@ -50,15 +53,25 @@ before_install:
 install: true
 
 before_script:
-  # Set BUILD_VERSION
+  # Set TARGET Docker Repo
+  # default TARGET = nodered/node-red-dev
+  # if TRAVIS_TAG starts with a `v` and only contains numbers, dots and/or dash then TARGET = nodered/node-red
   - >
-    if [ ! -z "${TRAVIS_TAG}" ]; then
-      export BUILD_VERSION=${TRAVIS_TAG:1};
+    export TARGET=nodered/node-red-dev
+
+    if [[ "${TRAVIS_TAG}" =~ ^v[0-9\.-]*$ ]]; then
+      export TARGET=nodered/node-red
     fi
 
   # Set NODE_RED_VERSION from package.json
   - >
     export NODE_RED_VERSION=$(grep -oE "\"node-red\": \"(\w*.\w*.\w*.\w*.\w*.)" package.json | cut -d\" -f4)
+
+  # Set BUILD_VERSION
+  - >
+    if [ ! -z "${TRAVIS_TAG}" ]; then
+      export BUILD_VERSION=${TRAVIS_TAG:1};
+    fi
 
 script:
   # Build Docker image
@@ -67,7 +80,7 @@ script:
   # Test Docker image
   - ./.docker/docker.sh test
 
-  # Push Docker image, ony if TRAVIS_TAG is set
+  # Push Docker image, only if TRAVIS_TAG is set
   - >
     if [ ! -z "${TRAVIS_TAG}" ]; then
       # Tag Docker image
@@ -86,7 +99,7 @@ script:
 jobs:
     include:
         - stage: manifest
-          # Only create and push manifest list to Docker Hub, when tag starts with a `v`, eg. v0.20.8
+          # Only create and push manifest list to Docker Hub, when tag starts with a `v`, eg. v1.0.2
           if: tag =~ ^v
           script:
               # Create and push Docker manifest lists
@@ -105,19 +118,56 @@ jobs:
               - ./.docker/docker.sh manifest-list-version "10" "default"
               - ./.docker/docker.sh manifest-list-version "" "default"
 
-              # Create and push manifest list 'latest' or 'testing' for minimal
-              - ./.docker/docker.sh manifest-list-test-beta-latest "12" "minimal"
-              - ./.docker/docker.sh manifest-list-test-beta-latest "10" "minimal"
-              - ./.docker/docker.sh manifest-list-test-beta-latest "" "minimal"
+              # if TARGET = `nodered/node-red` then manifest lists get tagged as `latest` and push to `nodered/node-red`
+              # if tags contain `beta` then manifest lists get tagged as `beta` and push to `nodered/node-red-dev`
+              # if tags contain `dev` then manifest lists get tagged as `dev` and push to `nodered/node-red-dev`
+              # else manifest lists get tagged as `test` and push to `nodered/node-red-dev`
+              - >
+                if [[ "${TARGET}" == "nodered/node-red" ]]; then
+                  # Create and push manifest list `latest` for minimal
+                  ./.docker/docker.sh manifest_list_latest "12" "minimal"
+                  ./.docker/docker.sh manifest_list_latest "10" "minimal"
+                  ./.docker/docker.sh manifest_list_latest "" "minimal"
 
-              # Create and push manifest list 'latest' or 'testing' for default
-              - ./.docker/docker.sh manifest-list-test-beta-latest "12" "default"
-              - ./.docker/docker.sh manifest-list-test-beta-latest "10" "default"
-              - ./.docker/docker.sh manifest-list-test-beta-latest "" "default"
+                  # Create and push manifest list `latest` for default
+                  ./.docker/docker.sh manifest_list_latest "12" "default"
+                  ./.docker/docker.sh manifest_list_latest "10" "default"
+                  ./.docker/docker.sh manifest_list_latest "" "default"
+                elif [[ "${TRAVIS_TAG}" == *"beta"* ]]; then
+                  # Create and push manifest list `beta` for minimal
+                  ./.docker/docker.sh manifest_list_beta "12" "minimal"
+                  ./.docker/docker.sh manifest_list_beta "10" "minimal"
+                  ./.docker/docker.sh manifest_list_beta "" "minimal"
+
+                  # Create and push manifest list `beta` for default
+                  ./.docker/docker.sh manifest_list_beta "12" "default"
+                  ./.docker/docker.sh manifest_list_beta "10" "default"
+                  ./.docker/docker.sh manifest_list_beta "" "default"
+                elif [[ "${TRAVIS_TAG}" == *"dev"* ]]; then
+                  # Create and push manifest list `dev` for minimal
+                  ./.docker/docker.sh manifest_list_dev "12" "minimal"
+                  ./.docker/docker.sh manifest_list_dev "10" "minimal"
+                  ./.docker/docker.sh manifest_list_dev "" "minimal"
+
+                  # Create and push manifest list `dev` for default
+                  ./.docker/docker.sh manifest_list_dev "12" "default"
+                  ./.docker/docker.sh manifest_list_dev "10" "default"
+                  ./.docker/docker.sh manifest_list_dev "" "default"
+                else
+                  # Create and push manifest list `test` for minimal
+                  ./.docker/docker.sh manifest_list_test "12" "minimal"
+                  ./.docker/docker.sh manifest_list_test "10" "minimal"
+                  ./.docker/docker.sh manifest_list_test "" "minimal"
+
+                  # Create and push manifest list `test` for default
+                  ./.docker/docker.sh manifest_list_test "12" "default"
+                  ./.docker/docker.sh manifest_list_test "10" "default"
+                  ./.docker/docker.sh manifest_list_test "" "default"
+                fi
 
               # Docker Logout
               - docker logout
 
-# notify me when things fail
+# Notify me when things fail
 notifications:
   email: true

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/node-red/node-red-docker.svg)](https://greenkeeper.io/)
 [![Build Status](https://travis-ci.org/node-red/node-red-docker.svg?branch=master)](https://travis-ci.org/node-red/node-red-docker)
 [![DockerHub Pull](https://img.shields.io/docker/pulls/nodered/node-red.svg)](https://hub.docker.com/r/nodered/node-red/)
+[![DockerHub Stars](https://img.shields.io/docker/stars/nodered/node-red.svg?maxAge=2592000)](https://hub.docker.com/r/nodered/node-red/)
 
-This project describes some of the many ways Node-RED can be run under Docker and has support for multiple architectures (amd64, arm32v6, arm32v7, arm64v8, and s390x).
+This project describes some of the many ways Node-RED can be run under Docker and has support for multiple architectures (amd64, arm32v6, arm32v7, arm64v8, i386 and s390x).
 Some basic familiarity with Docker and the [Docker Command Line](https://docs.docker.com/engine/reference/commandline/cli/) is assumed.
 
 As of Node-RED 1.0 this project provides the build for the `nodered/node-red` container on [Docker Hub](https://hub.docker.com/r/nodered/node-red/). Note: the Docker Hub name has changed to `nodered/node-red`.
@@ -62,11 +63,6 @@ Running that command should give a terminal window with a running instance of No
 
 You can then browse to `http://{host-ip}:1880` to get the familiar Node-RED desktop.
 
-**Note**: Currently there is a bug in Docker's architecture detection that fails for Arm6 CPU - eg Raspberry Pi Zero or 1. For these devices you currently need to specify the full build label, for example:
-
-```
-docker run -it -p 1880:1880 --name mynodered nodered/node-red:1.0.1-10-arm32v6
-```
 
 The advantage of doing this is that by giving it a name (mynodered) we can manipulate it
 more easily, and by fixing the host port we know we are on familiar ground.
@@ -97,7 +93,7 @@ The tag naming convention is `<node-red-version>-<node-version>-<image-type>-<ar
 - `<image-type>` is type of image and is optional, can be either _none_ or minimal.
     - _none_ : is the default and has Python 2 & Python 3 + devtools installed
     - minimal : has no Python installed and no devtools installed
-- `<architecture>` is the architecture of the Docker host system, can be either amd64, arm32v6, arm32v7, arm64, or s390x
+- `<architecture>` is the architecture of the Docker host system, can be either amd64, arm32v6, arm32v7, arm64, s390x or i386.
 
 The minimal versions (without python and build tools) are not able to install nodes that require any locally compiled native code.
 
@@ -117,11 +113,15 @@ The following table shows the variety of provided Node-RED images.
 | 1.0.2-10-arm32v6           |   10   | arm32v6  |   2.x 3.x  |  yes  | arm32v6/node:10-alpine |
 | 1.0.2-10-arm32v7           |   10   | arm32v7  |   2.x 3.x  |  yes  | arm32v7/node:10-alpine |
 | 1.0.2-10-arm64v8           |   10   | arm64v8  |   2.x 3.x  |  yes  | arm64v8/node:10-alpine |
+| 1.0.2-10-s390x             |   10   | s390x    |   2.x 3.x  |  yes  | s390x/node:10-alpine   |
+| 1.0.2-10-i386              |   10   | i386     |   2.x 3.x  |  yes  | i386/node:10-alpine    |
 |                            |        |          |            |       |                        |
 | 1.0.2-10-minimal-amd64     |   10   | amd64    |     no     |  no   | amd64/node:10-alpine   |
 | 1.0.2-10-minimal-arm32v6   |   10   | arm32v6  |     no     |  no   | arm32v6/node:10-alpine |
 | 1.0.2-10-minimal-arm32v7   |   10   | arm32v7  |     no     |  no   | arm32v7/node:10-alpine |
 | 1.0.2-10-minimal-arm64v8   |   10   | arm64v8  |     no     |  no   | arm64v8/node:10-alpine |
+| 1.0.2-10-minimal-s390x     |   10   | s390x    |     no     |  no   | s390x/node:10-alpine   |
+| 1.0.2-10-minimal-i386      |   10   | i386     |     no     |  no   | i386/node:10-alpine    |
 
 
 | **Tag**                    |**Node**| **Arch** | **Python** |**Dev**| **Base Image**         |
@@ -130,11 +130,15 @@ The following table shows the variety of provided Node-RED images.
 | 1.0.2-12-arm32v6           |   12   | arm32v6  |   2.x 3.x  |  yes  | arm32v6/node:12-alpine |
 | 1.0.2-12-arm32v7           |   12   | arm32v7  |   2.x 3.x  |  yes  | arm32v7/node:12-alpine |
 | 1.0.2-12-arm64v8           |   12   | arm64v8  |   2.x 3.x  |  yes  | arm64v8/node:12-alpine |
+| 1.0.2-12-s390x             |   12   | s390x    |   2.x 3.x  |  yes  | s390x/node:12-alpine   |
+| 1.0.2-12-i386              |   12   | i386     |   2.x 3.x  |  yes  | i386/node:12-alpine    |
 |                            |        |          |            |       |                        |
 | 1.0.2-12-minimal-amd64     |   12   | amd64    |     no     |  no   | amd64/node:12-alpine   |
 | 1.0.2-12-minimal-arm32v6   |   12   | arm32v6  |     no     |  no   | arm32v6/node:12-alpine |
 | 1.0.2-12-minimal-arm32v7   |   12   | arm32v7  |     no     |  no   | arm32v7/node:12-alpine |
 | 1.0.2-12-minimal-arm64v8   |   12   | arm64v8  |     no     |  no   | arm64v8/node:12-alpine |
+| 1.0.2-12-minimal-s390x     |   12   | s390x    |     no     |  no   | s390x/node:12-alpine   |
+| 1.0.2-12-minimal-i386      |   12   | i386     |     no     |  no   | i386/node:12-alpine    |
 
 - All images have bash, tzdata, nano, curl git and openssl tools pre-installed to support Node-RED's Projects feature.
 
@@ -147,11 +151,15 @@ The following table shows the provided Manifest Lists.
 | latest-10, 1.0.2-10                    | nodered/node-red:1.0.2-10-arm32v6          |
 |                                        | nodered/node-red:1.0.2-10-arm32v7          |
 |                                        | nodered/node-red:1.0.2-10-arm64v8          |
+|                                        | nodered/node-red:1.0.2-10-s390x            |
+|                                        | nodered/node-red:1.0.2-10-i386             |
 |                                        |                                            |
 | latest-minimal, 1.0.2-minimal,         | nodered/node-red:1.0.2-10-amd64-minimal    |
 | latest-10-minimal, 1.0.2-10-minimal    | nodered/node-red:1.0.2-10-arm32v6-minimal  |
 |                                        | nodered/node-red:1.0.2-10-arm32v7-minimal  |
 |                                        | nodered/node-red:1.0.2-10-arm64v8-minimal  |
+|                                        | nodered/node-red:1.0.2-10-s390x-minimal    |
+|                                        | nodered/node-red:1.0.2-10-i386-minimal     |
 
 | **Tag**                                | **Node-RED Base Image**                    |
 |----------------------------------------|--------------------------------------------|
@@ -159,18 +167,22 @@ The following table shows the provided Manifest Lists.
 |                                        | nodered/node-red:1.0.2-12-arm32v6          |
 |                                        | nodered/node-red:1.0.2-12-arm32v7          |
 |                                        | nodered/node-red:1.0.2-12-arm64v8          |
+|                                        | nodered/node-red:1.0.2-12-s390x            |
+|                                        | nodered/node-red:1.0.2-12-i386             |
 |                                        |                                            |
 | latest-12-minimal, 1.0.2-12-minimal    | nodered/node-red:1.0.2-12-amd64-minimal    |
 |                                        | nodered/node-red:1.0.2-12-arm32v6-minimal  |
 |                                        | nodered/node-red:1.0.2-12-arm32v7-minimal  |
 |                                        | nodered/node-red:1.0.2-12-arm64v8-minimal  |
+|                                        | nodered/node-red:1.0.2-12-s390x-minimal    |
+|                                        | nodered/node-red:1.0.2-12-i386-minimal     |
 
 With the support of Docker manifest list, there is no need to explicitly add the tag for the architecture to use.
 When a docker run command or docker service command or docker stack command is executed, docker checks which architecture is required and verifies if it is available in the docker repository. If it does, docker pulls the matching image for it.
 
 Therefore all tags regarding Raspberry PI's are dropped.
 
-For example: suppose you are running on a Raspberry PI 3B, which has arm32v7 as architecture. Then just run the following command to pull the image (tagged by `1.0.2-10-arm32v7`), and run the container.
+For example: suppose you are running on a Raspberry PI 3B, which has `arm32v7` as architecture. Then just run the following command to pull the image (tagged by `1.0.2-10-arm32v7`), and run the container.
 ```
 docker run -it -p 1880:1880 --name mynodered nodered/node-red:latest
 ```
@@ -179,7 +191,7 @@ The same command can be used for running on an amd64 system, since docker discov
 
 This gives the advantage that you don't need to know/specify which architecture you are running on and makes docker run commands and docker compose files more flexible and exchangeable across systems.
 
-**Note**: Currently there is a bug in Docker's architecture detection that fails for Arm6 CPU - eg Raspberry Pi Zero or 1. For these devices you currently need to specify the full build label, for example:
+**Note**: Currently there is a bug in Docker's architecture detection that fails for `arm32v6` - eg Raspberry Pi Zero or 1. For these devices you currently need to specify the full image tag, for example:
 ```
 docker run -it -p 1880:1880 --name mynodered nodered/node-red:1.0.2-10-minimal-arm32v6
 ```
@@ -203,8 +215,6 @@ Disadvantages of the native GPIO support are:
   4. Configure `pi gpiod` nodes to connect to `PiGPIOd daemon`. Often the host machine will have an IP 172.17.0.1 port 8888 - but not always. You can use `docker exec -it mynodered ip route show default | awk '/default/ {print $3}'` to check.
 
 For detailed install instruction please refer to the `node-red-node-pi-gpiod` [README](https://github.com/node-red/node-red-nodes/tree/master/hardware/pigpiod#node-red-node-pi-gpiod)
-
-If you want to run gpiod in a container rather than on the host, then [this project](https://github.com/corbosman/node-red-gpiod) may help.
 
 **Note**: There is a contributed [gpiod project](https://github.com/corbosman/node-red-gpiod) that runs the gpiod in its own container rather than on the host if required.
 

--- a/docker-custom/Dockerfile.custom
+++ b/docker-custom/Dockerfile.custom
@@ -84,4 +84,7 @@ VOLUME ["/data"]
 # Expose the listening port of node-red
 EXPOSE 1880
 
+# Add a healthcheck (default every 30 secs)
+HEALTHCHECK CMD curl http://localhost:1880/ || exit 1
+
 ENTRYPOINT ["npm", "start", "--", "--userDir", "/data"]


### PR DESCRIPTION
The readme.md for node-red-docker says:
"All images have bash, tzdata, nano, curl git and openssl tools pre-installed to support Node-RED's Projects feature." 
but I don't think the build has openssl. I also notice that you have openSSH-server, could this be a typo. I use many nodes that require openssl such as node-red-contrib-iiot-opcua.

