### PR TITLE
Add debug mode start scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,38 @@ services:
     restart: unless-stopped
 ```
 
+## Debugging containers
+
+Sometimes it is useful to debug the code which is running inside the container.  Two scripts (*'debug'* and *'debug_brk'* in the package.json file) are available to start NodeJs in debug mode, which means that NodeJs will start listening (to port 9229) for a debug client.
+
+1. In most cases the *'debug'* script will be sufficient, to debug a Node-RED application that is already running.  The NodeJs server can be started in debug mode using following command:
+   ```
+   docker run -it -p 1880:1880 -p 9229:9229 --name mynodered --entrypoint npm nodered/node-red run debug -- --userDir /data
+   ```
+
+2. In case debugging of the Node-RED startup code is required, the  *'debug_brk'* script will instruct NodeJs to break at the first statement of the Node-RED application.  The NodeJs server can be started in debug mode using following command:
+   ```
+   docker run -it -p 1880:1880 -p 9229:9229 --name mynodered --entrypoint npm nodered/node-red run debug_brk -- --userDir /data
+   ```
+   Note that in this case NodeJs will wait - at the first statement of the Node-RED application - until a debugger client connects...
+   
+As soon as NodeJs is listening to the debug port, this will be shown in the startup log:
+```
+Debugger listening on ws://0.0.0.0:9229/...
+```
+
+Let's dissect both commands:
+
+        docker run              - run this container, initially building locally if necessary
+        -it                     - attach a terminal session so we can see what is going on
+        -p 1880:1880            - connect local port 1880 to the exposed internal port 1880
+        -p 9229:9229            - connect local port 9229 to the exposed internal port 9229 (for debugger communication)
+        --name mynodered        - give this machine a friendly local name
+        --entrypoint npm        - overwrite the default entrypoint (which would run the *'start'* script)
+        nodered/node-red        - the image to base it on - currently Node-RED v1.0.3
+        run debug(_brk)         - (npm) arguments for the custom endpoint (which must be added AFTER the image name!)
+        --                      - the arguments that will follow are not npm arguments, but need to be passed to the script
+        --userDir /data         - instruct the script where the Node-RED data needs to be stored
 
 ## Common Issues and Hints
 

--- a/README.md
+++ b/README.md
@@ -476,9 +476,9 @@ services:
 
 ## Debugging containers
 
-Sometimes it is useful to debug the code which is running inside the container.  Two scripts (*'debug'* and *'debug_brk'* in the package.json file) are available to start NodeJs in debug mode, which means that NodeJs will start listening (to port 9229) for a debug client.
+Sometimes it is useful to debug the code which is running inside the container.  Two scripts (*'debug'* and *'debug_brk'* in the package.json file) are available to start NodeJs in debug mode, which means that NodeJs will start listening (to port 9229) for a debug client. Various remote debugger tools (like Visual Code, Chrome Developer Tools ...) can be used to debug a Node-RED application.  A [wiki](https://github.com/node-red/node-red-docker/wiki/Debug-container-via-Chrome-Developer-Tools) page has been provided, to explain step-by-step how to use the Chrome Developer Tools debugger.
 
-1. In most cases the *'debug'* script will be sufficient, to debug a Node-RED application that is already running.  The NodeJs server can be started in debug mode using following command:
+1. In most cases the *'debug'* script will be sufficient, to debug a Node-RED application that is fully up-and-running (i.e. when the application startup code is not relevant).  The NodeJs server can be started in debug mode using following command:
    ```
    docker run -it -p 1880:1880 -p 9229:9229 --name mynodered --entrypoint npm nodered/node-red run debug -- --userDir /data
    ```

--- a/docker-custom/package.json
+++ b/docker-custom/package.json
@@ -10,7 +10,9 @@
     },
     "main": "node_modules/node-red/red/red.js",
     "scripts": {
-        "start": "node $NODE_OPTIONS node_modules/node-red/red.js $FLOWS"
+        "start": "node $NODE_OPTIONS node_modules/node-red/red.js $FLOWS",
+        "debug": "node --inspect=0.0.0.0:9229 $NODE_OPTIONS node_modules/node-red/red.js $FLOWS",
+        "debug_brk": "node --inspect=0.0.0.0:9229 --inspect-brk $NODE_OPTIONS node_modules/node-red/red.js $FLOWS"
     },
     "contributors": [
         {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     },
     "main": "node_modules/node-red/red/red.js",
     "scripts": {
-        "start": "node $NODE_OPTIONS node_modules/node-red/red.js $FLOWS"
+        "start": "node $NODE_OPTIONS node_modules/node-red/red.js $FLOWS",
+        "debug": "node --inspect=0.0.0.0:9229 $NODE_OPTIONS node_modules/node-red/red.js $FLOWS",
+        "debug_brk": "node --inspect=0.0.0.0:9229 --inspect-brk $NODE_OPTIONS node_modules/node-red/red.js $FLOWS"
     },
     "contributors": [
         {


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Proposed changes

Docker allows us to setup very easy new (test) environments.  However it would be nice if we could connect with a debugger to a Node-RED instance, to have remote debugging capabilities.

This pull request only adds two new scripts (*'debug'* and *'debug_brk'*) to the package.json file(s), to accomplish this.

I have discussed this new feature in [this](https://discourse.nodered.org/t/debugging-nodejs-in-node-red-docker-container/21370) Discourse discussion, where I got a green light from @dceejay :-)

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [X] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [X] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
