### PR TITLE
Fix docker RUN instructions so that images build, resolves #169

### DIFF
--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -73,7 +73,7 @@ COPY --from=build /usr/src/node-red/prod_node_modules ./node_modules
 # Chown, install devtools & Clean up
 RUN chown -R node-red:node-red /usr/src/node-red && \
     /tmp/install_devtools.sh && \
-    rm /tmp/* && \
+    rm -r /tmp/* && \
     rm /usr/bin/qemu-$QEMU_ARCH-static
 
 USER node-red

--- a/docker-custom/Dockerfile.custom
+++ b/docker-custom/Dockerfile.custom
@@ -67,7 +67,7 @@ COPY --from=build /usr/src/node-red/prod_node_modules ./node_modules
 # Chown, install devtools & Clean up
 RUN chown -R node-red:node-red /usr/src/node-red && \
     /tmp/install_devtools.sh && \
-    rm /tmp/*
+    rm -r /tmp/*
 
 USER node-red
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

Currently if you clone down [node-red-docker](https://github.com/node-red/node-red-docker) and run  `./docker-make.sh` it fails to build an image with an error:
```
rm: '/tmp/v8-compile-cache-0' is a directory
The command '/bin/sh -c chown -R node-red:node-red /usr/src/node-red &&     /tmp/install_devtools.sh &&     rm /tmp/*' returned a non-zero code: 1
```

I was able to fix the issue by adding a recursive flag to the `RUN` instruction in the `Dockerfile.custom` on line 70:
```
# Chown, install devtools & Clean up
RUN chown -R node-red:node-red /usr/src/node-red && \
    /tmp/install_devtools.sh && \
    rm -r /tmp/*
```

After submitting this PR I noticed that the TravisCI builds were failing for the same reason, and adding the recursive flag to the broken RUN instruction seemed to fix that as well.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
