### PR TITLE
Manual update for v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Let's dissect that command:
         -p 1880:1880            - connect local port 1880 to the exposed internal port 1880
         -v node_red_data:/data  - mount the host node_red_data directory to the container /data directory so any changes made to flows are persisted
         --name mynodered        - give this machine a friendly local name
-        nodered/node-red        - the image to base it on - currently Node-RED v1.3.5
+        nodered/node-red        - the image to base it on - currently Node-RED v2.0.0
 
 
 Running that command should give a terminal window with a running instance of Node-RED.
@@ -34,8 +34,8 @@ Running that command should give a terminal window with a running instance of No
         Welcome to Node-RED
         ===================
 
-        10 Oct 12:57:10 - [info] Node-RED version: v1.3.5
-        10 Oct 12:57:10 - [info] Node.js  version: v10.22.1
+        10 Oct 12:57:10 - [info] Node-RED version: v2.0.0
+        10 Oct 12:57:10 - [info] Node.js  version: v12.22.2
         10 Oct 12:57:10 - [info] Linux 4.19.76-linuxkit x64 LE
         10 Oct 12:57:11 - [info] Loading palette nodes
         10 Oct 12:57:16 - [info] Settings file  : /data/settings.js
@@ -114,36 +114,35 @@ The following table shows the variety of provided Node-RED images.
 
 | **Tag**                    |**Node**| **Arch** | **Python** |**Dev**| **Base Image**         |
 |----------------------------|--------|----------|------------|-------|------------------------|
-| 1.3.5-10-amd64             |   10   | amd64    |   2.x 3.x  |  yes  | amd64/node:10-alpine   |
-| 1.3.5-10-arm32v6           |   10   | arm32v6  |   2.x 3.x  |  yes  | arm32v6/node:10-alpine |
-| 1.3.5-10-arm32v7           |   10   | arm32v7  |   2.x 3.x  |  yes  | arm32v7/node:10-alpine |
-| 1.3.5-10-arm64v8           |   10   | arm64v8  |   2.x 3.x  |  yes  | arm64v8/node:10-alpine |
-| 1.3.5-10-s390x             |   10   | s390x    |   2.x 3.x  |  yes  | s390x/node:10-alpine   |
-| 1.3.5-10-i386              |   10   | i386     |   2.x 3.x  |  yes  | i386/node:10-alpine    |
+| 2.0.0-12-amd64             |   12   | amd64    |   2.x 3.x  |  yes  | amd64/node:12-alpine   |
+| 2.0.0-12-arm32v6           |   12   | arm32v6  |   2.x 3.x  |  yes  | arm32v6/node:12-alpine |
+| 2.0.0-12-arm32v7           |   12   | arm32v7  |   2.x 3.x  |  yes  | arm32v7/node:12-alpine |
+| 2.0.0-12-arm64v8           |   12   | arm64v8  |   2.x 3.x  |  yes  | arm64v8/node:12-alpine |
+| 2.0.0-12-s390x             |   12   | s390x    |   2.x 3.x  |  yes  | s390x/node:12-alpine   |
+| 2.0.0-12-i386              |   12   | i386     |   2.x 3.x  |  yes  | i386/node:12-alpine    |
 |                            |        |          |            |       |                        |
-| 1.3.5-10-minimal-amd64     |   10   | amd64    |     no     |  no   | amd64/node:10-alpine   |
-| 1.3.5-10-minimal-arm32v6   |   10   | arm32v6  |     no     |  no   | arm32v6/node:10-alpine |
-| 1.3.5-10-minimal-arm32v7   |   10   | arm32v7  |     no     |  no   | arm32v7/node:10-alpine |
-| 1.3.5-10-minimal-arm64v8   |   10   | arm64v8  |     no     |  no   | arm64v8/node:10-alpine |
-| 1.3.5-10-minimal-s390x     |   10   | s390x    |     no     |  no   | s390x/node:10-alpine   |
-| 1.3.5-10-minimal-i386      |   10   | i386     |     no     |  no   | i386/node:10-alpine    |
-
+| 2.0.0-12-minimal-amd64     |   12   | amd64    |     no     |  no   | amd64/node:12-alpine   |
+| 2.0.0-12-minimal-arm32v6   |   12   | arm32v6  |     no     |  no   | arm32v6/node:12-alpine |
+| 2.0.0-12-minimal-arm32v7   |   12   | arm32v7  |     no     |  no   | arm32v7/node:12-alpine |
+| 2.0.0-12-minimal-arm64v8   |   12   | arm64v8  |     no     |  no   | arm64v8/node:12-alpine |
+| 2.0.0-12-minimal-s390x     |   12   | s390x    |     no     |  no   | s390x/node:12-alpine   |
+| 2.0.0-12-minimal-i386      |   12   | i386     |     no     |  no   | i386/node:12-alpine    |
 
 | **Tag**                    |**Node**| **Arch** | **Python** |**Dev**| **Base Image**         |
 |----------------------------|--------|----------|------------|-------|------------------------|
-| 1.3.5-12-amd64             |   12   | amd64    |   2.x 3.x  |  yes  | amd64/node:12-alpine   |
-| 1.3.5-12-arm32v6           |   12   | arm32v6  |   2.x 3.x  |  yes  | arm32v6/node:12-alpine |
-| 1.3.5-12-arm32v7           |   12   | arm32v7  |   2.x 3.x  |  yes  | arm32v7/node:12-alpine |
-| 1.3.5-12-arm64v8           |   12   | arm64v8  |   2.x 3.x  |  yes  | arm64v8/node:12-alpine |
-| 1.3.5-12-s390x             |   12   | s390x    |   2.x 3.x  |  yes  | s390x/node:12-alpine   |
-| 1.3.5-12-i386              |   12   | i386     |   2.x 3.x  |  yes  | i386/node:12-alpine    |
+| 2.0.0-14-amd64             |   14   | amd64    |   2.x 3.x  |  yes  | amd64/node:14-alpine   |
+| 2.0.0-14-arm32v6           |   14   | arm32v6  |   2.x 3.x  |  yes  | arm32v6/node:14-alpine |
+| 2.0.0-14-arm32v7           |   14   | arm32v7  |   2.x 3.x  |  yes  | arm32v7/node:14-alpine |
+| 2.0.0-14-arm64v8           |   14   | arm64v8  |   2.x 3.x  |  yes  | arm64v8/node:14-alpine |
+| 2.0.0-14-s390x             |   14   | s390x    |   2.x 3.x  |  yes  | s390x/node:14-alpine   |
+| 2.0.0-14-i386              |   14   | i386     |   2.x 3.x  |  yes  | i386/node:14-alpine    |
 |                            |        |          |            |       |                        |
-| 1.3.5-12-minimal-amd64     |   12   | amd64    |     no     |  no   | amd64/node:12-alpine   |
-| 1.3.5-12-minimal-arm32v6   |   12   | arm32v6  |     no     |  no   | arm32v6/node:12-alpine |
-| 1.3.5-12-minimal-arm32v7   |   12   | arm32v7  |     no     |  no   | arm32v7/node:12-alpine |
-| 1.3.5-12-minimal-arm64v8   |   12   | arm64v8  |     no     |  no   | arm64v8/node:12-alpine |
-| 1.3.5-12-minimal-s390x     |   12   | s390x    |     no     |  no   | s390x/node:12-alpine   |
-| 1.3.5-12-minimal-i386      |   12   | i386     |     no     |  no   | i386/node:12-alpine    |
+| 2.0.0-14-minimal-amd64     |   14   | amd64    |     no     |  no   | amd64/node:14-alpine   |
+| 2.0.0-14-minimal-arm32v6   |   14   | arm32v6  |     no     |  no   | arm32v6/node:14-alpine |
+| 2.0.0-14-minimal-arm32v7   |   14   | arm32v7  |     no     |  no   | arm32v7/node:14-alpine |
+| 2.0.0-14-minimal-arm64v8   |   14   | arm64v8  |     no     |  no   | arm64v8/node:14-alpine |
+| 2.0.0-14-minimal-s390x     |   14   | s390x    |     no     |  no   | s390x/node:14-alpine   |
+| 2.0.0-14-minimal-i386      |   14   | i386     |     no     |  no   | i386/node:14-alpine    |
 
 - All images have bash, tzdata, nano, curl, git, openssl and openssh-client pre-installed to support Node-RED's Projects feature.
 
@@ -152,53 +151,53 @@ The following table shows the provided Manifest Lists.
 
 | **Tag**                                | **Node-RED Base Image**                    |
 |----------------------------------------|--------------------------------------------|
-| latest, 1.3.5,                         | nodered/node-red:1.3.5-10-amd64            |
-| latest-10, 1.3.5-10                    | nodered/node-red:1.3.5-10-arm32v6          |
-|                                        | nodered/node-red:1.3.5-10-arm32v7          |
-|                                        | nodered/node-red:1.3.5-10-arm64v8          |
-|                                        | nodered/node-red:1.3.5-10-s390x            |
-|                                        | nodered/node-red:1.3.5-10-i386             |
+| latest, 2.0.0,                         | nodered/node-red:2.0.0-12-amd64            |
+| latest-10, 2.0.0-12                    | nodered/node-red:2.0.0-12-arm32v6          |
+|                                        | nodered/node-red:2.0.0-12-arm32v7          |
+|                                        | nodered/node-red:2.0.0-12-arm64v8          |
+|                                        | nodered/node-red:2.0.0-12-s390x            |
+|                                        | nodered/node-red:2.0.0-12-i386             |
 |                                        |                                            |
-| latest-minimal, 1.3.5-minimal,         | nodered/node-red:1.3.5-10-amd64-minimal    |
-| latest-10-minimal, 1.3.5-10-minimal    | nodered/node-red:1.3.5-10-arm32v6-minimal  |
-|                                        | nodered/node-red:1.3.5-10-arm32v7-minimal  |
-|                                        | nodered/node-red:1.3.5-10-arm64v8-minimal  |
-|                                        | nodered/node-red:1.3.5-10-s390x-minimal    |
-|                                        | nodered/node-red:1.3.5-10-i386-minimal     |
+| latest-minimal, 2.0.0-minimal,         | nodered/node-red:2.0.0-12-amd64-minimal    |
+| latest-10-minimal, 2.0.0-12-minimal    | nodered/node-red:2.0.0-12-arm32v6-minimal  |
+|                                        | nodered/node-red:2.0.0-12-arm32v7-minimal  |
+|                                        | nodered/node-red:2.0.0-12-arm64v8-minimal  |
+|                                        | nodered/node-red:2.0.0-12-s390x-minimal    |
+|                                        | nodered/node-red:2.0.0-12-i386-minimal     |
 
 | **Tag**                                | **Node-RED Base Image**                    |
 |----------------------------------------|--------------------------------------------|
-| latest-12, 1.3.5-12                    | nodered/node-red:1.3.5-12-amd64            |
-|                                        | nodered/node-red:1.3.5-12-arm32v6          |
-|                                        | nodered/node-red:1.3.5-12-arm32v7          |
-|                                        | nodered/node-red:1.3.5-12-arm64v8          |
-|                                        | nodered/node-red:1.3.5-12-s390x            |
-|                                        | nodered/node-red:1.3.5-12-i386             |
+| latest-12, 2.0.0-12                    | nodered/node-red:2.0.0-14-amd64            |
+|                                        | nodered/node-red:2.0.0-14-arm32v6          |
+|                                        | nodered/node-red:2.0.0-14-arm32v7          |
+|                                        | nodered/node-red:2.0.0-14-arm64v8          |
+|                                        | nodered/node-red:2.0.0-14-s390x            |
+|                                        | nodered/node-red:2.0.0-14-i386             |
 |                                        |                                            |
-| latest-12-minimal, 1.3.5-12-minimal    | nodered/node-red:1.3.5-12-amd64-minimal    |
-|                                        | nodered/node-red:1.3.5-12-arm32v6-minimal  |
-|                                        | nodered/node-red:1.3.5-12-arm32v7-minimal  |
-|                                        | nodered/node-red:1.3.5-12-arm64v8-minimal  |
-|                                        | nodered/node-red:1.3.5-12-s390x-minimal    |
-|                                        | nodered/node-red:1.3.5-12-i386-minimal     |
+| latest-12-minimal, 2.0.0-12-minimal    | nodered/node-red:2.0.0-14-amd64-minimal    |
+|                                        | nodered/node-red:2.0.0-14-arm32v6-minimal  |
+|                                        | nodered/node-red:2.0.0-14-arm32v7-minimal  |
+|                                        | nodered/node-red:2.0.0-14-arm64v8-minimal  |
+|                                        | nodered/node-red:2.0.0-14-s390x-minimal    |
+|                                        | nodered/node-red:2.0.0-14-i386-minimal     |
 
 With the support of Docker manifest list, there is no need to explicitly add the tag for the architecture to use.
 When a docker run command or docker service command or docker stack command is executed, docker checks which architecture is required and verifies if it is available in the docker repository. If it does, docker pulls the matching image for it.
 
 Therefore all tags regarding Raspberry PI's are dropped.
 
-For example: suppose you are running on a Raspberry PI 3B, which has `arm32v7` as architecture. Then just run the following command to pull the image (tagged by `1.3.5-10-arm32v7`), and run the container.
+For example: suppose you are running on a Raspberry PI 3B, which has `arm32v7` as architecture. Then just run the following command to pull the image (tagged by `2.0.0-13-arm32v7`), and run the container.
 ```
 docker run -it -p 1880:1880 -v node_red_data:/data --name mynodered nodered/node-red:latest
 ```
 
-The same command can be used for running on an amd64 system, since docker discovers its running on a amd64 host and pulls the image with the matching tag (`1.3.5-10-amd64`).
+The same command can be used for running on an amd64 system, since docker discovers its running on a amd64 host and pulls the image with the matching tag (`2.0.0-13-amd64`).
 
 This gives the advantage that you don't need to know/specify which architecture you are running on and makes docker run commands and docker compose files more flexible and exchangeable across systems.
 
 **Note**: Currently there is a bug in Docker's architecture detection that fails for `arm32v6` - eg Raspberry Pi Zero or 1. For these devices you currently need to specify the full image tag, for example:
 ```
-docker run -it -p 1880:1880 -v node_red_data:/data --name mynodered nodered/node-red:1.3.5-10-minimal-arm32v6
+docker run -it -p 1880:1880 -v node_red_data:/data --name mynodered nodered/node-red:2.0.0-13-minimal-arm32v6
 
 ```
 
@@ -332,7 +331,7 @@ Docker build process, the dependencies are installed under `/usr/src/node-red`.
 The main sections to modify are
 
     "dependencies": {
-        "node-red": "^1.3.5",           <-- set the version of Node-RED here
+        "node-red": "^2.0.0",           <-- set the version of Node-RED here
         "node-red-dashboard": "*"        <-- add any extra npm packages here
     },
 

--- a/docker-custom/package.json
+++ b/docker-custom/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-docker",
-    "version": "1.3.5",
+    "version": "2.0.0",
     "description": "Low-code programming for event-driven applications",
     "homepage": "http://nodered.org",
     "license": "Apache-2.0",
@@ -29,9 +29,9 @@
         }
     ],
     "dependencies": {
-        "node-red": "1.3.5"
+        "node-red": "2.0.0"
     },
     "engines": {
-        "node": ">=10"
+        "node": ">=12"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-docker",
-    "version": "1.3.5",
+    "version": "2.0.0",
     "description": "Low-code programming for event-driven applications",
     "homepage": "http://nodered.org",
     "license": "Apache-2.0",
@@ -29,9 +29,9 @@
         }
     ],
     "dependencies": {
-        "node-red": "1.3.5"
+        "node-red": "2.0.0"
     },
     "engines": {
-        "node": ">=10"
+        "node": ">=12"
     }
 }


### PR DESCRIPTION
Replacement PR for the automatically generated ver to bump the Nodejs versions as well as the Node-RED version ahead of the v2.0.0 Docker Build