### PR TITLE
Remove Python 2

### DIFF
--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -44,7 +44,7 @@ COPY flows.json /data
 FROM base AS build
 
 # Install Build tools
-RUN apk add --no-cache --virtual buildtools build-base linux-headers udev python2 && \
+RUN apk add --no-cache --virtual buildtools build-base linux-headers udev python3 && \
     npm install --unsafe-perm --no-update-notifier --no-audit --no-fund --only=production && \
     /tmp/remove_native_gpio.sh && \
     cp -R node_modules prod_node_modules

--- a/docker-custom/Dockerfile.custom
+++ b/docker-custom/Dockerfile.custom
@@ -43,7 +43,7 @@ COPY flows.json /data
 FROM base AS build
 
 # Install Build tools
-RUN apk add --no-cache --virtual buildtools build-base linux-headers udev python2 && \
+RUN apk add --no-cache --virtual buildtools build-base linux-headers udev python3 && \
     npm install --unsafe-perm --no-update-notifier --no-fund --only=production && \
     /tmp/remove_native_gpio.sh && \
     cp -R node_modules prod_node_modules

--- a/docker-custom/package.json
+++ b/docker-custom/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-docker",
-    "version": "3.0.0-beta.2",
+    "version": "3.0.0-beta.3",
     "description": "Low-code programming for event-driven applications",
     "homepage": "http://nodered.org",
     "license": "Apache-2.0",
@@ -29,7 +29,7 @@
         }
     ],
     "dependencies": {
-        "node-red": "3.0.0-beta.2"
+        "node-red": "3.0.0-beta.3"
     },
     "engines": {
         "node": ">=12"

--- a/docker-custom/scripts/install_devtools.sh
+++ b/docker-custom/scripts/install_devtools.sh
@@ -4,7 +4,7 @@ set -ex
 # Installing Devtools
 if [[ ${TAG_SUFFIX} != *"minimal" ]]; then
   echo "Installing devtools"
-  apk add --no-cache --virtual devtools build-base linux-headers udev python2 python3
+  apk add --no-cache --virtual devtools build-base linux-headers udev python3
 else
   echo "Skip installing devtools"
 fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-docker",
-    "version": "3.0.0-beta.2",
+    "version": "3.0.0-beta.3",
     "description": "Low-code programming for event-driven applications",
     "homepage": "http://nodered.org",
     "license": "Apache-2.0",
@@ -29,7 +29,7 @@
         }
     ],
     "dependencies": {
-        "node-red": "3.0.0-beta.2"
+        "node-red": "3.0.0-beta.3"
     },
     "engines": {
         "node": ">=12"


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Alpine 3.16 has totally dropped Python 2 (which went end of life 2020)

This change leaves the Docker container with only Python3 installed.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
