### PR TITLE
Fix passing cli args to Node-RED

### DIFF
--- a/docker-custom/scripts/entrypoint.sh
+++ b/docker-custom/scripts/entrypoint.sh
@@ -7,7 +7,7 @@ function stop() {
 	wait $CHILD_PID
 }
 
-/usr/local/bin/node $NODE_OPTIONS node_modules/node-red/red.js --userDir /data $FLOWS &
+/usr/local/bin/node $NODE_OPTIONS node_modules/node-red/red.js --userDir /data $FLOWS "${@}" &
 
 CHILD_PID="$!"
 


### PR DESCRIPTION
The new entrypoint introduced in https://github.com/node-red/node-red-docker/pull/324 does not forward arguments to Node-RED. (which is a breaking change from 3.0.0)

With this change the old behavior is restored and one can override settings via the docker command again.

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
