### PR TITLE
Remove `npm set python`

### DIFF
--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -82,7 +82,6 @@ RUN chown -R node-red:root /usr/src/node-red && \
     rm -r /tmp/*
 
 RUN npm config set cache /data/.npm --global
-RUN npm config set python `which python3` --global
 
 USER node-red
 

--- a/docker-custom/Dockerfile.custom
+++ b/docker-custom/Dockerfile.custom
@@ -80,7 +80,6 @@ RUN chown -R node-red:root /usr/src/node-red && \
     rm -r /tmp/*
 
 RUN npm config set cache /data/.npm --global 
-RUN npm config set python `which python3` --global
 
 USER node-red
 

--- a/docker-custom/Dockerfile.debian
+++ b/docker-custom/Dockerfile.debian
@@ -81,7 +81,6 @@ RUN chown -R node-red:root /usr/src/node-red && \
     rm -r /tmp/*
 
 RUN npm config set cache /data/.npm --global
-RUN npm config set python `which python3` --global
 
 USER node-red
 


### PR DESCRIPTION
This npm option has been removed from npm so fails with newer builds

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Remove `npm set python` as it was removed in npm v9 and fails

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
