### PR TITLE
Bump package to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Let's dissect that command:
         -p 1880:1880            - connect local port 1880 to the exposed internal port 1880
         -v node_red_data:/data  - mount the host node_red_data directory to the container /data directory so any changes made to flows are persisted
         --name mynodered        - give this machine a friendly local name
-        nodered/node-red        - the image to base it on - currently Node-RED v3.0.2
+        nodered/node-red        - the image to base it on - currently Node-RED v3.1.0
 
 
 Running that command should give a terminal window with a running instance of Node-RED.
@@ -34,7 +34,7 @@ Running that command should give a terminal window with a running instance of No
         Welcome to Node-RED
         ===================
 
-        10 Oct 12:57:10 - [info] Node-RED version: v3.0.2
+        10 Oct 12:57:10 - [info] Node-RED version: v3.1.0
         10 Oct 12:57:10 - [info] Node.js  version: v16.14.1
         10 Oct 12:57:10 - [info] Linux 4.19.76-linuxkit x64 LE
         10 Oct 12:57:11 - [info] Loading palette nodes
@@ -114,14 +114,14 @@ The following table shows the variety of provided Node-RED images.
 
 | **Tag**                    |**Node**| **Arch** | **Python** |**Dev**| **Base Image**             |
 |----------------------------|--------|----------|------------|-------|----------------------------|
-| 3.0.2-14                   |   14   | amd64    |   2.x 3.x  |  yes  | amd64/node:14-alpine       |
+| 3.1.0-14                   |   14   | amd64    |   2.x 3.x  |  yes  | amd64/node:14-alpine       |
 |                            |   14   | arm32v6  |   2.x 3.x  |  yes  | arm32v6/node:14-alpine     |
 |                            |   14   | arm32v7  |   2.x 3.x  |  yes  | arm32v7/node:14-alpine     |
 |                            |   14   | arm64v8  |   2.x 3.x  |  yes  | arm64v8/node:14-alpine     |
 |                            |   14   | s390x    |   2.x 3.x  |  yes  | s390x/node:14-alpine       |
 |                            |   14   | i386     |   2.x 3.x  |  yes  | i386/node:14-alpine        |
 |                            |        |          |            |       |                            |
-| 3.0.2-14-minimal           |   14   | amd64    |     no     |  no   | amd64/node:14-alpine       |
+| 3.1.0-14-minimal           |   14   | amd64    |     no     |  no   | amd64/node:14-alpine       |
 |                            |   14   | arm32v6  |     no     |  no   | arm32v6/node:14-alpine     |
 |                            |   14   | arm32v7  |     no     |  no   | arm32v7/node:14-alpine     |
 |                            |   14   | arm64v8  |     no     |  no   | arm64v8/node:14-alpine     |
@@ -130,14 +130,14 @@ The following table shows the variety of provided Node-RED images.
 
 | **Tag**                    |**Node**| **Arch** | **Python** |**Dev**| **Base Image**             |
 |----------------------------|--------|----------|------------|-------|----------------------------|
-| 3.0.2-16                   |   14   | amd64    |   2.x 3.x  |  yes  | amd64/node:16-alpine       |
+| 3.1.0-16                   |   14   | amd64    |   2.x 3.x  |  yes  | amd64/node:16-alpine       |
 |                            |   14   | arm32v6  |   2.x 3.x  |  yes  | arm32v6/node:16-alpine     |
 |                            |   14   | arm32v7  |   2.x 3.x  |  yes  | arm32v7/node:16-alpine     |
 |                            |   14   | arm64v8  |   2.x 3.x  |  yes  | arm64v8/node:16-alpine     |
 |                            |   14   | s390x    |   2.x 3.x  |  yes  | s390x/node:16-alpine       |
 |                            |   14   | i386     |   2.x 3.x  |  yes  | i386/node:16-alpine        |
 |                            |        |          |            |       |                            |
-| 3.0.2-16-minimal           |   14   | amd64    |     no     |  no   | amd64/node:14-alpine       |
+| 3.1.0-16-minimal           |   14   | amd64    |     no     |  no   | amd64/node:14-alpine       |
 |                            |   14   | arm32v6  |     no     |  no   | arm32v6/node:14-alpine     |
 |                            |   14   | arm32v7  |     no     |  no   | arm32v7/node:14-alpine     |
 |                            |   14   | arm64v8  |     no     |  no   | arm64v8/node:14-alpine     |
@@ -146,14 +146,14 @@ The following table shows the variety of provided Node-RED images.
 
 | **Tag**                    |**Node**| **Arch** | **Python** |**Dev**| **Base Image**             |
 |----------------------------|--------|----------|------------|-------|----------------------------|
-| 3.0.2-18                   |   18   | amd64    |   2.x 3.x  |  yes  | amd64/node:18-alpine       |
+| 3.1.0-18                   |   18   | amd64    |   2.x 3.x  |  yes  | amd64/node:18-alpine       |
 |                            |   18   | arm32v6  |   2.x 3.x  |  yes  | arm32v6/node:18-alpine     |
 |                            |   18   | arm32v7  |   2.x 3.x  |  yes  | arm32v7/node:18-alpine     |
 |                            |   18   | arm64v8  |   2.x 3.x  |  yes  | arm64v8/node:18-alpine     |
 |                            |   18   | s390x    |   2.x 3.x  |  yes  | s390x/node:18-alpine       |
 |                            |   18   | i386     |   2.x 3.x  |  yes  | i386/node:18-alpine        |
 |                            |        |          |            |       |                            |
-| 3.0.2-18-minimal           |   18   | amd64    |     no     |  no   | amd64/node:18-alpine       |
+| 3.1.0-18-minimal           |   18   | amd64    |     no     |  no   | amd64/node:18-alpine       |
 |                            |   18   | arm32v6  |     no     |  no   | arm32v6/node:18-alpine     |
 |                            |   18   | arm32v7  |     no     |  no   | arm32v7/node:18-alpine     |
 |                            |   18   | arm64v8  |     no     |  no   | arm64v8/node:18-alpine     |
@@ -167,25 +167,25 @@ The following table shows the provided Manifest Lists.
 
 | **Tag**                                | **Node-RED Base Image**                    |
 |----------------------------------------|--------------------------------------------|
-| latest, 3.0.2,                         | nodered/node-red:3.0.2-16                  |
-| latest-16, 3.0.2-16                    |                                            |
+| latest, 3.1.0,                         | nodered/node-red:3.1.0-16                  |
+| latest-16, 3.1.0-16                    |                                            |
 |                                        |                                            |
 |                                        |                                            |
-| latest-minimal, 3.0.2-minimal,         | nodered/node-red:3.0.2-16-minimal          |
-| latest-16-minimal, 3.0.2-16-minimal    |                                            |
+| latest-minimal, 3.1.0-minimal,         | nodered/node-red:3.1.0-16-minimal          |
+| latest-16-minimal, 3.1.0-16-minimal    |                                            |
 
 
 | **Tag**                                | **Node-RED Base Image**                    |
 |----------------------------------------|--------------------------------------------|
-| latest-14, 3.0.2-14                    | nodered/node-red:3.0.2-12                  |
+| latest-14, 3.1.0-14                    | nodered/node-red:3.1.0-12                  |
 |                                        |                                            |
-| latest-14-minimal, 3.0.2-14-minimal    | nodered/node-red:3.0.2-12-minimal          |
+| latest-14-minimal, 3.1.0-14-minimal    | nodered/node-red:3.1.0-12-minimal          |
 
 | **Tag**                                | **Node-RED Base Image**                    |
 |----------------------------------------|--------------------------------------------|
-| latest-18, 3.0.2-18                    | nodered/node-red:3.0.2-18                  |
+| latest-18, 3.1.0-18                    | nodered/node-red:3.1.0-18                  |
 |                                        |                                            |
-| latest-18-minimal, 3.0.2-18-minimal    | nodered/node-red:3.0.2-18-minimal          
+| latest-18-minimal, 3.1.0-18-minimal    | nodered/node-red:3.1.0-18-minimal          
 
 
 With the support of Docker manifest list, there is no need to explicitly add the tag for the architecture to use.
@@ -193,13 +193,13 @@ When a docker run command or docker service command or docker stack command is e
 
 Therefore all tags regarding Raspberry PI's are dropped.
 
-For example: suppose you are running on a Raspberry PI 3B, which has `arm32v7` as architecture. Then just run the following command to pull the image (tagged by `3.0.2-16`), and run the container.
+For example: suppose you are running on a Raspberry PI 3B, which has `arm32v7` as architecture. Then just run the following command to pull the image (tagged by `3.1.0-16`), and run the container.
 
 ```
 docker run -it -p 1880:1880 -v node_red_data:/data --name mynodered nodered/node-red:latest
 ```
 
-The same command can be used for running on an amd64 system, since docker discovers its running on a amd64 host and pulls the image with the matching tag (`3.0.2-16-amd64`).
+The same command can be used for running on an amd64 system, since docker discovers its running on a amd64 host and pulls the image with the matching tag (`3.1.0-16-amd64`).
 
 This gives the advantage that you don't need to know/specify which architecture you are running on and makes docker run commands and docker compose files more flexible and exchangeable across systems.
 
@@ -334,7 +334,7 @@ Docker build process, the dependencies are installed under `/usr/src/node-red`.
 The main sections to modify are
 
     "dependencies": {
-        "node-red": "^3.0.2",           <-- set the version of Node-RED here
+        "node-red": "^3.1.0",           <-- set the version of Node-RED here
         "node-red-dashboard": "*"        <-- add any extra npm packages here
     },
 

--- a/docker-custom/package.json
+++ b/docker-custom/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-docker",
-    "version": "3.0.2",
+    "version": "3.1.0",
     "description": "Low-code programming for event-driven applications",
     "homepage": "http://nodered.org",
     "license": "Apache-2.0",
@@ -29,7 +29,7 @@
         }
     ],
     "dependencies": {
-        "node-red": "3.0.2"
+        "node-red": "3.1.0"
     },
     "engines": {
         "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-docker",
-    "version": "3.0.2",
+    "version": "3.1.0",
     "description": "Low-code programming for event-driven applications",
     "homepage": "http://nodered.org",
     "license": "Apache-2.0",
@@ -29,7 +29,7 @@
         }
     ],
     "dependencies": {
-        "node-red": "3.0.2"
+        "node-red": "3.1.0"
     },
     "engines": {
         "node": ">=14"


### PR DESCRIPTION
The automated task to do this updated when 3.1.0 was released has failed due to, I think, an out of date dependency in the workflow.

Rather than debug that, this is a manual PR to apply the necessary changes.