### PR TITLE
Remove linux/s390x for now 3.0.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,7 @@ jobs:
         continue-on-error: true
         with:
           context: .
-          platforms: linux/amd64, linux/arm64, linux/s390x, linux/arm/v7, linux/arm/v6
+          platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/arm/v6
           push: ${{ steps.nrVersion.outputs.push }}
           file: .docker/Dockerfile.alpine 
           build-args: |


### PR DESCRIPTION
Disabling building for linux/s309x until the building on qemu with docker is fixed.

https://github.com/nodejs/node/issues/50339

Doing this so I can respin the containers to pick up upstream fixes (e.g. curl CVE)