### PR TITLE
Remove continue on error so the build fails if problem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,6 @@ jobs:
         name: Build and push
         id: build-push
         uses: docker/build-push-action@v5
-        continue-on-error: true
         with:
           context: .
           platforms: linux/amd64, linux/arm64


### PR DESCRIPTION
Build failed due to npm timeout on some builds but reported all passed so got missed.

This will cause a reported failure so it can be respun.