### PR TITLE
Remove i386 entries from Node version tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,27 +119,23 @@ The following table shows the variety of provided Node-RED images.
 | 4.1.7-18                   |   18   | amd64    |    3.x     |  yes  | amd64/node:18-alpine       |
 |                            |   18   | arm32v7  |    3.x     |  yes  | arm32v7/node:18-alpine     |
 |                            |   18   | arm64v8  |    3.x     |  yes  | arm64v8/node:18-alpine     |
-|                            |   18   | i386     |    3.x     |  yes  | i386/node:18-alpine        |
 |                            |        |          |            |       |                            |
 | 4.1.7-18-minimal           |   18   | amd64    |     no     |  no   | amd64/node:18-alpine       |
 |                            |   18   | arm32v7  |     no     |  no   | arm32v7/node:18-alpine     |
 |                            |   18   | arm64v8  |     no     |  no   | arm64v8/node:18-alpine     |
-|                            |   18   | i386     |     no     |  no   | i386/node:18-alpine        |
 
 | **Tag**                    |**Node**| **Arch** | **Python** |**Dev**| **Base Image**             |
 |----------------------------|--------|----------|------------|-------|----------------------------|
 | 4.1.7-20                   |   20   | amd64    |    3.x     |  yes  | amd64/node:20-alpine       |
 |                            |   20   | arm32v7  |    3.x     |  yes  | arm32v7/node:20-alpine     |
 |                            |   20   | arm64v8  |    3.x     |  yes  | arm64v8/node:20-alpine     |
-|                            |   20   | i386     |    3.x     |  yes  | i386/node:20-alpine        |
 |                            |        |          |            |       |                            |
 | 4.1.7-20-minimal           |   20   | amd64    |     no     |  no   | amd64/node:20-alpine       |
 |                            |   20   | arm32v7  |     no     |  no   | arm32v7/node:20-alpine     |
 |                            |   20   | arm64v8  |     no     |  no   | arm64v8/node:20-alpine     |
-|                            |   20   | i386     |     no     |  no   | i386/node:20-alpine        |
 |                            |        |          |            |       |                            |
 | 4.1.7-debian               |   20   | amd64    |    3.x     |  yes  | amd64/node:20-buster-slim  |
-|                            |   20   | arm32v7  |    3.x     |  yes  | amd64/node:20-buster-slim  |
+|                            |   20   | arm32v7  |    3.x     |  yes  | arm32v7/node:20-buster-slim  |
 |                            |   20   | arm64v8  |    3.x     |  yes  | amd64/node:20-buster-slim  |
 
 | **Tag**                    |**Node**| **Arch** | **Python** |**Dev**| **Base Image**             |
@@ -147,12 +143,11 @@ The following table shows the variety of provided Node-RED images.
 | 4.1.7-22                   |   22   | amd64    |    3.x     |  yes  | amd64/node:22-alpine       |
 |                            |   22   | arm32v7  |    3.x     |  yes  | arm32v7/node:22-alpine     |
 |                            |   22   | arm64v8  |    3.x     |  yes  | arm64v8/node:22-alpine     |
-|                            |   22   | i386     |    3.x     |  yes  | i386/node:22-alpine        |
 |                            |        |          |            |       |                            |
 | 4.1.7-22-minimal           |   22   | amd64    |     no     |  no   | amd64/node:22-alpine       |
 |                            |   22   | arm32v7  |     no     |  no   | arm32v7/node:22-alpine     |
 |                            |   22   | arm64v8  |     no     |  no   | arm64v8/node:22-alpine     |
-|                            |   22   | i386     |     no     |  no   | i386/node:22-alpine        |
+
 
 - All images have bash, tzdata, nano, curl, git, openssl and openssh-client pre-installed to support Node-RED's Projects feature.
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Removed i386 architecture entries from various Node versions and updated the arm32v7 entry for the 20-debian image.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
