### PR TITLE
Update README to remove unsupported architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,10 @@ The following table shows the variety of provided Node-RED images.
 | **Tag**                    |**Node**| **Arch** | **Python** |**Dev**| **Base Image**             |
 |----------------------------|--------|----------|------------|-------|----------------------------|
 | 5.0.0-beta.3-24                   |   24   | amd64    |    3.x     |  yes  | amd64/node:24-alpine       |
-|                            |   24   | arm32v7  |    3.x     |  yes  | arm32v7/node:24-alpine     |
 |                            |   24   | arm64v8  |    3.x     |  yes  | arm64v8/node:24-alpine     |
-|                            |   24   | i386     |    3.x     |  yes  | i386/node:24-alpine        |
 |                            |        |          |            |       |                            |
 | 5.0.0-beta.3-24-minimal           |   24   | amd64    |     no     |  no   | amd64/node:24-alpine       |
-|                            |   24   | arm32v7  |     no     |  no   | arm32v7/node:24-alpine     |
 |                            |   24   | arm64v8  |     no     |  no   | arm64v8/node:24-alpine     |
-|                            |   24   | i386     |     no     |  no   | i386/node:24-alpine        |
 
 - All images have bash, tzdata, nano, curl, git, openssl and openssh-client pre-installed to support Node-RED's Projects feature.
 
@@ -134,8 +130,6 @@ The following table shows the provided Manifest Lists.
 
 | **Tag**                                | **Node-RED Base Image**                    |
 |----------------------------------------|--------------------------------------------|
-| latest-22, 5.0.0-beta.3-24                    | nodered/node-red:5.0.0-beta.3-24                  |
-|                                        |                                            |
 | latest-24-minimal, 5.0.0-beta.3-24-minimal    | nodered/node-red:5.0.0-beta.3-24-minimal          
 
 


### PR DESCRIPTION
<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->
Removed entries for arm32v7, i386 architectures from the table and updated the description regarding Docker manifest lists.

This is from the dev branch (what will be NR 5.0, remove all the 32bit builds as they don't exist and only listing NodeJS 24 (will add 26 later), might as well never ship 22 to keep everything with the longest possible life.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
